### PR TITLE
First attempt at handling job folders

### DIFF
--- a/relion/_parser/ctffind.py
+++ b/relion/_parser/ctffind.py
@@ -1,11 +1,23 @@
 class CTFFind:
     def __init__(self, path):
-        self.basepath = path
-        print("CTFFind created!")
+        self._basepath = path
+        self._jobcache = {}
 
     def __str__(self):
-        return f"I'm a CTFFind instance at {self.basepath}"
+        return f"I'm a CTFFind instance at {self._basepath}"
 
     @property
-    def plate_colour(self):
-        return "green"
+    def jobs(self):
+        return sorted(d.stem for d in self._basepath.iterdir() if d.is_dir())
+
+    def __getitem__(self, key):
+        if not isinstance(key, str):
+            raise KeyError(f"Invalid argument {key!r}, expected string")
+        if key not in self._jobcache:
+            job_path = self._basepath / key
+            if not job_path.is_dir():
+                raise KeyError(
+                    f"no job directory present for {key} in {self._basepath}"
+                )
+            self._jobcache[key] = job_path
+        return self._jobcache[key]

--- a/tests/parser/test_ctffind.py
+++ b/tests/parser/test_ctffind.py
@@ -1,0 +1,20 @@
+import pytest
+import relion
+
+
+@pytest.fixture
+def ctffind(dials_data):
+    return relion.Project(dials_data("relion_tutorial_data")).ctffind
+
+
+def test_list_ctffind_jobs(ctffind):
+    assert ctffind
+    assert list(ctffind.jobs) == ["job003"]
+    assert ctffind["job003"]
+
+
+def test_invalid_job_references_raise_KeyErrors(ctffind):
+    for reference in ("job004", None, 1):
+        with pytest.raises(KeyError):
+            print("Checking", reference)
+            ctffind[reference]


### PR DESCRIPTION
So this is a bit of work on the parser/ctffind object, which now allows you to get a list of job directories and you can access them by indexing, ie.

`relion.Project(some_path).ctffind["job003"]`