### PR TITLE
Fix path representation check on Windows

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -6,7 +6,7 @@ def test_basic_Project_object_behaviour(tmp_path):
     rp1 = relion.Project(tmp_path)
     assert rp1
     assert str(tmp_path) in str(rp1)
-    assert str(tmp_path) in repr(rp1)
+    assert tmp_path.name in repr(rp1)
 
     rp2 = relion.Project(str(tmp_path))
     assert rp2


### PR DESCRIPTION
Handling backslashes is a bit tricky on Windows, so just check that the
final path component is present