### PR TITLE
Turn Class2D into a Mapping

### DIFF
--- a/relion/_parser/class2D.py
+++ b/relion/_parser/class2D.py
@@ -1,9 +1,10 @@
-from gemmi import cif
+import collections.abc
 import os
 import functools
 from collections import namedtuple
 from collections import Counter
 
+from gemmi import cif
 
 Class2DMicrograph = namedtuple(
     "Class2DMicrograph",
@@ -18,10 +19,16 @@ Class2DMicrograph = namedtuple(
 )
 
 
-class Class2D:
+class Class2D(collections.abc.Mapping):
     def __init__(self, path):
         self._basepath = path
         self._jobcache = {}
+
+    def __iter__(self):
+        return (x.name for x in self._basepath.iterdir())
+
+    def __len__(self):
+        return len(self._basepath.iterdir())
 
     def __str__(self):
         return f"I'm a Class2D instance at {self._basepath}"

--- a/tests/parser/test_class2D.py
+++ b/tests/parser/test_class2D.py
@@ -30,6 +30,15 @@ def test_class2d_behaves_like_a_dictionary(class2d):
     assert list(dc.values()) == list(class2d.values())
 
 
+def test_class2d_dictionary_is_identical_to_construct_dict(class2d):
+    original_class2d_dict = class2d.construct_dict()
+    assert list(original_class2d_dict) == list(class2d)
+    from pprint import pprint
+
+    pprint(dict(class2d))
+    assert dict(original_class2d_dict) == dict(class2d)
+
+
 def test_job_num(input):
     class2d_object = input
     assert class2d_object.job_number[0] == "job008"

--- a/tests/parser/test_class2D.py
+++ b/tests/parser/test_class2D.py
@@ -5,8 +5,29 @@ from pprint import pprint
 
 
 @pytest.fixture
-def input(dials_data):
+def class2d(dials_data):
     return relion.Project(dials_data("relion_tutorial_data")).class2D
+
+
+input = class2d
+
+
+def test_list_all_jobs_in_class2d_directory(class2d):
+    """
+    When used in an iterator context the Class2D instance returns
+    all known job and alias names.
+    """
+    assert sorted(class2d) == ["job008", "job013"]
+
+
+def test_class2d_behaves_like_a_dictionary(class2d):
+    """
+    Class2D implements the Mapping abstract baseclass,
+    in other words it behaves like a fancy dictionary.
+    """
+    dc = dict(class2d)
+    assert list(dc) == list(class2d.keys()) == list(class2d)
+    assert list(dc.values()) == list(class2d.values())
 
 
 def test_job_num(input):


### PR DESCRIPTION
This adds behaviour to `Class2D` instances so that the object becomes equivalent to
```python
{
   "job008": <Path>,
   "job013": <Path>,
}
```

That is: We can use `list(class2d)` and `dict(class2d)` and `class2d.values()` and `class2d[jobname]` to get information about the class2d stage and about a specific job within the class2d stage.

(Obviously we will want to eventually get rid of the `<Path>` object in there and replace it with the information contained in that path.)