### PR TITLE
Change the iter methods of the different relion job types so that they exclude symbolic links

### DIFF
--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -52,7 +52,7 @@ class Class2D(collections.abc.Mapping):
         return iter(self.jobs)
 
     def __len__(self):
-        return sum(1 for d in self.jobs)
+        return len(self.jobs)
 
     def __repr__(self):
         return f"Class2D({repr(str(self._basepath))})"

--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -52,7 +52,7 @@ class Class2D(collections.abc.Mapping):
         return iter(self.jobs)
 
     def __len__(self):
-        return sum(1 for d in self._basepath.iterdir() if d.is_dir())
+        return sum(1 for d in self.jobs)
 
     def __repr__(self):
         return f"Class2D({repr(str(self._basepath))})"

--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -62,7 +62,11 @@ class Class2D(collections.abc.Mapping):
 
     @property
     def jobs(self):
-        return sorted(d.name for d in self._basepath.iterdir() if d.is_dir())
+        return sorted(
+            d.name
+            for d in self._basepath.iterdir()
+            if d.is_dir() and not d.is_symlink()
+        )
 
     def __getitem__(self, key):
         if not isinstance(key, str):

--- a/src/relion/_parser/class3D.py
+++ b/src/relion/_parser/class3D.py
@@ -52,7 +52,7 @@ class Class3D(collections.abc.Mapping):
         return iter(self.jobs)
 
     def __len__(self):
-        return len(list(self._basepath.iterdir()))
+        return sum(1 for d in self.jobs)
 
     def __repr__(self):
         return f"Class3D({repr(str(self._basepath))})"

--- a/src/relion/_parser/class3D.py
+++ b/src/relion/_parser/class3D.py
@@ -62,7 +62,11 @@ class Class3D(collections.abc.Mapping):
 
     @property
     def jobs(self):
-        return sorted(d.stem for d in self._basepath.iterdir() if d.is_dir())
+        return sorted(
+            d.stem
+            for d in self._basepath.iterdir()
+            if d.is_dir() and not d.is_symlink()
+        )
 
     def __getitem__(self, key):
         if not isinstance(key, str):

--- a/src/relion/_parser/class3D.py
+++ b/src/relion/_parser/class3D.py
@@ -49,7 +49,7 @@ class Class3D(collections.abc.Mapping):
         self._jobcache = {}
 
     def __iter__(self):
-        return (x.name for x in self._basepath.iterdir())
+        return iter(self.jobs)
 
     def __len__(self):
         return len(list(self._basepath.iterdir()))

--- a/src/relion/_parser/class3D.py
+++ b/src/relion/_parser/class3D.py
@@ -52,7 +52,7 @@ class Class3D(collections.abc.Mapping):
         return iter(self.jobs)
 
     def __len__(self):
-        return sum(1 for d in self.jobs)
+        return len(self.jobs)
 
     def __repr__(self):
         return f"Class3D({repr(str(self._basepath))})"

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -51,7 +51,7 @@ class CTFFind(collections.abc.Mapping):
         return iter(self.jobs)
 
     def __len__(self):
-        return len(list(self._basepath.iterdir()))
+        return sum(1 for d in self.jobs)
 
     def __repr__(self):
         return f"CTFFind({repr(str(self._basepath))})"

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -48,7 +48,7 @@ class CTFFind(collections.abc.Mapping):
         self._jobcache = {}
 
     def __iter__(self):
-        return (x.name for x in self._basepath.iterdir())
+        return iter(self.jobs)
 
     def __len__(self):
         return len(list(self._basepath.iterdir()))

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -51,7 +51,7 @@ class CTFFind(collections.abc.Mapping):
         return iter(self.jobs)
 
     def __len__(self):
-        return sum(1 for d in self.jobs)
+        return len(self.jobs)
 
     def __repr__(self):
         return f"CTFFind({repr(str(self._basepath))})"

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -61,7 +61,11 @@ class CTFFind(collections.abc.Mapping):
 
     @property
     def jobs(self):
-        return sorted(d.stem for d in self._basepath.iterdir() if d.is_dir())
+        return sorted(
+            d.stem
+            for d in self._basepath.iterdir()
+            if d.is_dir() and not d.is_symlink()
+        )
 
     def __getitem__(self, key):
         if not isinstance(key, str):

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -32,7 +32,7 @@ class MotionCorr(collections.abc.Mapping):
         self._jobcache = {}
 
     def __iter__(self):
-        return (x.name for x in self._basepath.iterdir())
+        return iter(self.jobs)
 
     def __len__(self):
         return len(self._basepath.iterdir())

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -45,7 +45,11 @@ class MotionCorr(collections.abc.Mapping):
 
     @property
     def jobs(self):
-        return sorted(d.stem for d in self._basepath.iterdir() if d.is_dir())
+        return sorted(
+            d.stem
+            for d in self._basepath.iterdir()
+            if d.is_dir() and not d.is_symlink()
+        )
 
     def __getitem__(self, key):
         if not isinstance(key, str):

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -35,7 +35,7 @@ class MotionCorr(collections.abc.Mapping):
         return iter(self.jobs)
 
     def __len__(self):
-        return len(self._basepath.iterdir())
+        return len(list(self._basepath.iterdir()))
 
     def __repr__(self):
         return f"MotionCorr({repr(str(self._basepath))})"

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -35,7 +35,7 @@ class MotionCorr(collections.abc.Mapping):
         return iter(self.jobs)
 
     def __len__(self):
-        return sum(1 for d in self.jobs)
+        return len(self.jobs)
 
     def __repr__(self):
         return f"MotionCorr({repr(str(self._basepath))})"

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -35,7 +35,7 @@ class MotionCorr(collections.abc.Mapping):
         return iter(self.jobs)
 
     def __len__(self):
-        return len(list(self._basepath.iterdir()))
+        return sum(1 for d in self.jobs)
 
     def __repr__(self):
         return f"MotionCorr({repr(str(self._basepath))})"

--- a/tests/parser/test_class2D.py
+++ b/tests/parser/test_class2D.py
@@ -1,6 +1,5 @@
 import pytest
 import relion
-import pathlib
 import sys
 from pprint import pprint
 
@@ -24,13 +23,13 @@ def test_list_all_jobs_in_class2d_directory(class2d):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_list_all_jobs_in_class2d_directory_symlink(proj):
+def test_aliases_are_dropped_on_iterating_so_jobs_arent_double_counted(proj):
     """
     Test that aliases are dropped so that jobs aren't double
     counted when iterated over
     """
-    symlink = pathlib.Path(proj.basepath / "Class2D/LoG")
-    symlink.symlink_to(proj.basepath / "Class2D/job008/")
+    symlink = proj.basepath / "Class2D" / "LoG"
+    symlink.symlink_to(proj.basepath / "Class2D" / "job008")
     sym_class2d = proj.class2D
     assert sorted(sym_class2d) == ["job008", "job013"]
     symlink.unlink()
@@ -47,19 +46,19 @@ def test_class2d_behaves_like_a_dictionary(class2d):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_len_symlink(proj):
+def test_len_drops_symlinks_from_the_job_count_to_avoid_double_counting(proj):
     """
     Test that __len__ has the correct behaviour when symlinks
     are present
     """
-    symlink = pathlib.Path(proj.basepath / "Class2D/LoG")
-    symlink.symlink_to(proj.basepath / "Class2D/job008/")
+    symlink = proj.basepath / "Class2D" / "LoG"
+    symlink.symlink_to(proj.basepath / "Class2D" / "job008")
     sym_class2d = proj.class2D
     assert len(sym_class2d) == 2
     symlink.unlink()
 
 
-def test_len(class2d):
+def test_len_returns_correct_number_of_jobs(class2d):
     """
     Test that __len__ has the correct behaviour
     """

--- a/tests/parser/test_class2D.py
+++ b/tests/parser/test_class2D.py
@@ -46,6 +46,13 @@ def test_class2d_behaves_like_a_dictionary(class2d):
     assert list(dc.values()) == list(class2d.values())
 
 
+def test_len(class2d):
+    """
+    Test that __len__ has the correct behaviour
+    """
+    assert len(class2d) == 2
+
+
 def test_jobs_are_in_correct_order_and_unique(class2d):
     assert list(class2d) == ["job008", "job013"]
     assert len(set(class2d)) == len(class2d)

--- a/tests/parser/test_class2D.py
+++ b/tests/parser/test_class2D.py
@@ -46,6 +46,19 @@ def test_class2d_behaves_like_a_dictionary(class2d):
     assert list(dc.values()) == list(class2d.values())
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def test_len_symlink(proj):
+    """
+    Test that __len__ has the correct behaviour when symlinks
+    are present
+    """
+    symlink = pathlib.Path(proj.basepath / "Class2D/LoG")
+    symlink.symlink_to(proj.basepath / "Class2D/job008/")
+    sym_class2d = proj.class2D
+    assert len(sym_class2d) == 2
+    symlink.unlink()
+
+
 def test_len(class2d):
     """
     Test that __len__ has the correct behaviour

--- a/tests/parser/test_class3D.py
+++ b/tests/parser/test_class3D.py
@@ -28,6 +28,13 @@ def test_list_all_jobs_in_class3d_directory_symlink(proj):
     symlink.unlink()
 
 
+def test_len(class3d_object):
+    """
+    Test that __len__ has the correct behaviour
+    """
+    assert len(class3d_object) == 1
+
+
 def test_job_num(class3d_object):
     pprint(dict(class3d_object))
     assert list(dict(class3d_object).keys())[0] == "job016"

--- a/tests/parser/test_class3D.py
+++ b/tests/parser/test_class3D.py
@@ -1,6 +1,5 @@
 import pytest
 import relion
-import pathlib
 import sys
 from pprint import pprint
 
@@ -16,19 +15,19 @@ def class3d_object(proj):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_list_all_jobs_in_class3d_directory_symlink(proj):
+def test_aliases_are_dropped_on_iterating_so_jobs_arent_double_counted(proj):
     """
     Test that aliases are dropped so that jobs aren't double
     counted when iterated over
     """
-    symlink = pathlib.Path(proj.basepath / "Class3D/first_exhaustive")
-    symlink.symlink_to(proj.basepath / "Class3D/job016/")
+    symlink = proj.basepath / "Class3D" / "first_exhaustive"
+    symlink.symlink_to(proj.basepath / "Class3D" / "job016")
     sym_class3d = proj.class3D
     assert sorted(sym_class3d) == ["job016"]
     symlink.unlink()
 
 
-def test_len(class3d_object):
+def test_len_returns_correct_number_of_jobs(class3d_object):
     """
     Test that __len__ has the correct behaviour
     """
@@ -36,13 +35,13 @@ def test_len(class3d_object):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_len_symlink(proj):
+def test_len_drops_symlinks_from_the_job_count_to_avoid_double_counting(proj):
     """
     Test that __len__ has the correct behaviour when symlinks
     are present
     """
-    symlink = pathlib.Path(proj.basepath / "Class3D/first_exhaustive")
-    symlink.symlink_to(proj.basepath / "Class3D/job016/")
+    symlink = proj.basepath / "Class3D" / "first_exhaustive"
+    symlink.symlink_to(proj.basepath / "Class3D" / "job016")
     sym_class3d = proj.class3D
     assert len(sym_class3d) == 1
     symlink.unlink()

--- a/tests/parser/test_class3D.py
+++ b/tests/parser/test_class3D.py
@@ -1,11 +1,31 @@
 import pytest
 import relion
+import pathlib
+import sys
 from pprint import pprint
 
 
 @pytest.fixture
-def class3d_object(dials_data):
-    return relion.Project(dials_data("relion_tutorial_data")).class3D
+def proj(dials_data):
+    return relion.Project(dials_data("relion_tutorial_data"))
+
+
+@pytest.fixture
+def class3d_object(proj):
+    return proj.class3D
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def test_list_all_jobs_in_class3d_directory_symlink(proj):
+    """
+    Test that aliases are dropped so that jobs aren't double
+    counted when iterated over
+    """
+    symlink = pathlib.Path(proj.basepath / "Class3D/first_exhaustive")
+    symlink.symlink_to(proj.basepath / "Class3D/job016/")
+    sym_class3d = proj.class3D
+    assert sorted(sym_class3d) == ["job016"]
+    symlink.unlink()
 
 
 def test_job_num(class3d_object):

--- a/tests/parser/test_class3D.py
+++ b/tests/parser/test_class3D.py
@@ -35,6 +35,19 @@ def test_len(class3d_object):
     assert len(class3d_object) == 1
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def test_len_symlink(proj):
+    """
+    Test that __len__ has the correct behaviour when symlinks
+    are present
+    """
+    symlink = pathlib.Path(proj.basepath / "Class3D/first_exhaustive")
+    symlink.symlink_to(proj.basepath / "Class3D/job016/")
+    sym_class3d = proj.class3D
+    assert len(sym_class3d) == 1
+    symlink.unlink()
+
+
 def test_job_num(class3d_object):
     pprint(dict(class3d_object))
     assert list(dict(class3d_object).keys())[0] == "job016"

--- a/tests/parser/test_ctffind.py
+++ b/tests/parser/test_ctffind.py
@@ -41,6 +41,19 @@ def test_len(ctffind):
     assert len(ctffind) == 1
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def test_len_symlink(proj):
+    """
+    Test that __len__ has the correct behaviour when symlinks
+    are present
+    """
+    symlink = pathlib.Path(proj.basepath / "CtfFind/ctffind4")
+    symlink.symlink_to(proj.basepath / "CtfFind/job003/")
+    sym_ctffind = proj.ctffind
+    assert len(sym_ctffind) == 1
+    symlink.unlink()
+
+
 def test_all_keys_are_different(ctffind):
     dictionary = dict(ctffind)
     key_list = list(dictionary.keys())

--- a/tests/parser/test_ctffind.py
+++ b/tests/parser/test_ctffind.py
@@ -1,5 +1,4 @@
 import pytest
-import pathlib
 import sys
 import relion
 
@@ -22,19 +21,19 @@ def test_list_ctffind_jobs(ctffind):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_list_all_jobs_in_ctffind_directory_symlink(proj):
+def test_aliases_are_dropped_on_iterating_so_jobs_arent_double_counted(proj):
     """
     Test that aliases are dropped so that jobs aren't double
     counted when iterated over
     """
-    symlink = pathlib.Path(proj.basepath / "CtfFind/ctffind4")
-    symlink.symlink_to(proj.basepath / "Class2D/job003/")
+    symlink = proj.basepath / "CtfFind" / "ctffind4"
+    symlink.symlink_to(proj.basepath / "Class2D" / "job003")
     sym_ctffind = proj.ctffind
     assert sorted(sym_ctffind) == ["job003"]
     symlink.unlink()
 
 
-def test_len(ctffind):
+def test_len_returns_correct_number_of_jobs(ctffind):
     """
     Test that __len__ has the correct behaviour
     """
@@ -42,13 +41,13 @@ def test_len(ctffind):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_len_symlink(proj):
+def test_len_drops_symlinks_from_the_job_count_to_avoid_double_counting(proj):
     """
     Test that __len__ has the correct behaviour when symlinks
     are present
     """
-    symlink = pathlib.Path(proj.basepath / "CtfFind/ctffind4")
-    symlink.symlink_to(proj.basepath / "CtfFind/job003/")
+    symlink = proj.basepath / "CtfFind" / "ctffind4"
+    symlink.symlink_to(proj.basepath / "CtfFind" / "job003")
     sym_ctffind = proj.ctffind
     assert len(sym_ctffind) == 1
     symlink.unlink()

--- a/tests/parser/test_ctffind.py
+++ b/tests/parser/test_ctffind.py
@@ -1,10 +1,17 @@
 import pytest
+import pathlib
+import sys
 import relion
 
 
 @pytest.fixture
-def ctffind(dials_data):
-    return relion.Project(dials_data("relion_tutorial_data")).ctffind
+def proj(dials_data):
+    return relion.Project(dials_data("relion_tutorial_data"))
+
+
+@pytest.fixture
+def ctffind(proj):
+    return proj.ctffind
 
 
 def test_list_ctffind_jobs(ctffind):
@@ -12,6 +19,19 @@ def test_list_ctffind_jobs(ctffind):
     assert len(ctffind) == 1
     assert list(ctffind.jobs) == ["job003"]
     assert ctffind["job003"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def test_list_all_jobs_in_ctffind_directory_symlink(proj):
+    """
+    Test that aliases are dropped so that jobs aren't double
+    counted when iterated over
+    """
+    symlink = pathlib.Path(proj.basepath / "CtfFind/ctffind4")
+    symlink.symlink_to(proj.basepath / "Class2D/job003/")
+    sym_ctffind = proj.ctffind
+    assert sorted(sym_ctffind) == ["job003"]
+    symlink.unlink()
 
 
 def test_all_keys_are_different(ctffind):

--- a/tests/parser/test_ctffind.py
+++ b/tests/parser/test_ctffind.py
@@ -34,6 +34,13 @@ def test_list_all_jobs_in_ctffind_directory_symlink(proj):
     symlink.unlink()
 
 
+def test_len(ctffind):
+    """
+    Test that __len__ has the correct behaviour
+    """
+    assert len(ctffind) == 1
+
+
 def test_all_keys_are_different(ctffind):
     dictionary = dict(ctffind)
     key_list = list(dictionary.keys())

--- a/tests/parser/test_motioncorrection.py
+++ b/tests/parser/test_motioncorrection.py
@@ -33,6 +33,13 @@ def test_list_all_jobs_in_motioncorr_directory_symlink(proj):
     symlink.unlink()
 
 
+def test_len(input):
+    """
+    Test that __len__ has the correct behaviour
+    """
+    assert len(input) == 1
+
+
 def test_job_num(input):
     mc_object = input
     pprint(dict(mc_object))

--- a/tests/parser/test_motioncorrection.py
+++ b/tests/parser/test_motioncorrection.py
@@ -1,16 +1,36 @@
 import pytest
 import relion
+import pathlib
+import sys
 from pprint import pprint
 
 
 @pytest.fixture
-def input(dials_data):
-    return relion.Project(dials_data("relion_tutorial_data")).motioncorrection
+def proj(dials_data):
+    return relion.Project(dials_data("relion_tutorial_data"))
+
+
+@pytest.fixture
+def input(proj):
+    return proj.motioncorrection
 
 
 @pytest.fixture
 def invalid_input(dials_data):
     return relion.Project(dials_data("relion_tutorial_data"))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def test_list_all_jobs_in_motioncorr_directory_symlink(proj):
+    """
+    Test that aliases are dropped so that jobs aren't double
+    counted when iterated over
+    """
+    symlink = pathlib.Path(proj.basepath / "MotionCorr/relioncor2")
+    symlink.symlink_to(proj.basepath / "MotionCorr/job002/")
+    sym_motioncorr = proj.motioncorrection
+    assert sorted(sym_motioncorr) == ["job002"]
+    symlink.unlink()
 
 
 def test_job_num(input):

--- a/tests/parser/test_motioncorrection.py
+++ b/tests/parser/test_motioncorrection.py
@@ -1,6 +1,5 @@
 import pytest
 import relion
-import pathlib
 import sys
 from pprint import pprint
 
@@ -21,19 +20,19 @@ def invalid_input(dials_data):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_list_all_jobs_in_motioncorr_directory_symlink(proj):
+def test_aliases_are_dropped_on_iterating_so_jobs_arent_double_counted(proj):
     """
     Test that aliases are dropped so that jobs aren't double
     counted when iterated over
     """
-    symlink = pathlib.Path(proj.basepath / "MotionCorr/relioncor2")
-    symlink.symlink_to(proj.basepath / "MotionCorr/job002/")
+    symlink = proj.basepath / "MotionCorr" / "relioncor2"
+    symlink.symlink_to(proj.basepath / "MotionCorr" / "job002")
     sym_motioncorr = proj.motioncorrection
     assert sorted(sym_motioncorr) == ["job002"]
     symlink.unlink()
 
 
-def test_len(input):
+def test_len_returns_correct_number_of_jobs(input):
     """
     Test that __len__ has the correct behaviour
     """
@@ -41,13 +40,13 @@ def test_len(input):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_len_symlink(proj):
+def test_len_drops_symlinks_from_the_job_count_to_avoid_double_counting(proj):
     """
     Test that __len__ has the correct behaviour when symlinks
     are present
     """
-    symlink = pathlib.Path(proj.basepath / "MotionCorr/relioncor2")
-    symlink.symlink_to(proj.basepath / "MotionCorr/job002/")
+    symlink = proj.basepath / "MotionCorr" / "relioncor2"
+    symlink.symlink_to(proj.basepath / "MotionCorr" / "job002")
     sym_motioncorr = proj.motioncorrection
     assert len(sym_motioncorr) == 1
     symlink.unlink()

--- a/tests/parser/test_motioncorrection.py
+++ b/tests/parser/test_motioncorrection.py
@@ -40,6 +40,19 @@ def test_len(input):
     assert len(input) == 1
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def test_len_symlink(proj):
+    """
+    Test that __len__ has the correct behaviour when symlinks
+    are present
+    """
+    symlink = pathlib.Path(proj.basepath / "MotionCorr/relioncor2")
+    symlink.symlink_to(proj.basepath / "MotionCorr/job002/")
+    sym_motioncorr = proj.motioncorrection
+    assert len(sym_motioncorr) == 1
+    symlink.unlink()
+
+
 def test_job_num(input):
     mc_object = input
     pprint(dict(mc_object))


### PR DESCRIPTION
This is a way to avoid double counting when looping over the jobs in a job type directory. All `__iter__` methods have also been changed to call `self.jobs`. This is what was done for class2D already and has been extended so that the other cases match. New tests have been added that create a sym-link inside the test dataset collected by `dials_data` and then test that this sym-link is not included when iterating over jobs. Are there circumstances in which it is desirable to have the alias names and if so could they be stored somewhere else? 