### PR TITLE
Refactor common functionality between job types into a JobType superclass

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.2.0
 commit = True
 tag = True
 
@@ -7,6 +7,6 @@ tag = True
 search = version = {current_version}
 replace = version = {new_version}
 
-[bumpversion:file:relion/__init__.py]
+[bumpversion:file:src/relion/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = relion
-version = 0.1.0
+version = 0.2.0
 description = Relion Python API
 long_description = file: README.rst
 author = Diamond Light Source - Scientific Software

--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -13,7 +13,7 @@ from relion._parser.class3D import Class3D
 __all__ = []
 __author__ = "Diamond Light Source - Scientific Software"
 __email__ = "scientificsoftware@diamond.ac.uk"
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __version_tuple__ = tuple(int(x) for x in __version__.split("."))
 
 

--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -1,10 +1,7 @@
-import collections.abc
-import os
-import functools
 from collections import namedtuple
 from collections import Counter
 from operator import attrgetter
-from gemmi import cif
+from relion._parser.jobtype import JobType
 
 Class2DParticleClass = namedtuple(
     "Class2DParticleClass",
@@ -35,50 +32,15 @@ Class2DParticleClass.overall_fourier_completeness.__doc__ = (
 )
 
 
-class Class2D(collections.abc.Mapping):
-    def __eq__(self, other):
-        if isinstance(other, Class2D):
-            return self._basepath == other._basepath
-        return False
-
+class Class2D(JobType):
     def __hash__(self):
         return hash(("relion._parser.Class2D", self._basepath))
-
-    def __init__(self, path):
-        self._basepath = path
-        self._jobcache = {}
-
-    def __iter__(self):
-        return iter(self.jobs)
-
-    def __len__(self):
-        return len(self.jobs)
 
     def __repr__(self):
         return f"Class2D({repr(str(self._basepath))})"
 
     def __str__(self):
         return f"<Class2D parser at {self._basepath}>"
-
-    @property
-    def jobs(self):
-        return sorted(
-            d.name
-            for d in self._basepath.iterdir()
-            if d.is_dir() and not d.is_symlink()
-        )
-
-    def __getitem__(self, key):
-        if not isinstance(key, str):
-            raise KeyError(f"Invalid argument {key!r}, expected string")
-        if key not in self._jobcache:
-            job_path = self._basepath / key
-            if not job_path.is_dir():
-                raise KeyError(
-                    f"no job directory present for {key} in {self._basepath}"
-                )
-            self._jobcache[key] = self._load_job_directory(key)
-        return self._jobcache[key]
 
     def _load_job_directory(self, jobdir):
 
@@ -135,21 +97,6 @@ class Class2D(collections.abc.Mapping):
             if not check_file.exists():
                 raise ValueError(f"File {check_file} missing from job directory")
         return data_file, model_file
-
-    @functools.lru_cache(maxsize=None)
-    def _read_star_file(self, job_num, file_name):
-        full_path = self._basepath / job_num / file_name
-        gemmi_readable_path = os.fspath(full_path)
-        star_doc = cif.read_file(gemmi_readable_path)
-        return star_doc
-
-    def parse_star_file(self, loop_name, star_doc, block_number):
-        data_block = star_doc[block_number]
-        values = data_block.find_loop(loop_name)
-        values_list = list(values)
-        if not values_list:
-            print("Warning - no values found for", loop_name)
-        return values_list
 
     def _count_all(self, list):
         count = Counter(list)

--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -44,25 +44,31 @@ class Class2D(JobType):
 
     def _load_job_directory(self, jobdir):
 
-        dfile, mfile = self._final_data_and_model(self._basepath / jobdir)
+        dfile, mfile = self._final_data_and_model(jobdir)
 
         sdfile = self._read_star_file(jobdir, dfile)
         smfile = self._read_star_file(jobdir, mfile)
 
-        class_distribution = self.parse_star_file("_rlnClassDistribution", smfile, 1)
-        accuracy_rotations = self.parse_star_file("_rlnAccuracyRotations", smfile, 1)
+        info_table = self._find_table_from_column_name("_rlnClassDistribution", smfile)
+
+        class_distribution = self.parse_star_file(
+            "_rlnClassDistribution", smfile, info_table
+        )
+        accuracy_rotations = self.parse_star_file(
+            "_rlnAccuracyRotations", smfile, info_table
+        )
         accuracy_translations_angst = self.parse_star_file(
-            "_rlnAccuracyTranslationsAngst", smfile, 1
+            "_rlnAccuracyTranslationsAngst", smfile, info_table
         )
         estimated_resolution = self.parse_star_file(
-            "_rlnEstimatedResolution", smfile, 1
+            "_rlnEstimatedResolution", smfile, info_table
         )
         overall_fourier_completeness = self.parse_star_file(
-            "_rlnOverallFourierCompleteness", smfile, 1
+            "_rlnOverallFourierCompleteness", smfile, info_table
         )
-        reference_image = self.parse_star_file("_rlnReferenceImage", smfile, 1)
+        reference_image = self.parse_star_file("_rlnReferenceImage", smfile, info_table)
 
-        class_numbers = self.parse_star_file("_rlnClassNumber", sdfile, 1)
+        class_numbers = self.parse_star_file("_rlnClassNumber", sdfile, info_table)
         particle_sum = self._sum_all_particles(class_numbers)
         int_particle_sum = [(int(name), value) for name, value in particle_sum.items()]
         checked_particle_list = self._class_checker(
@@ -85,15 +91,21 @@ class Class2D(JobType):
         return particle_class_list
 
     def _final_data_and_model(self, job_path):
-        number_list = [entry.stem[6:9] for entry in job_path.glob("run_it*.star")]
+        number_list = [
+            entry.stem[6:9]
+            for entry in (self._basepath / job_path).glob("run_it*.star")
+        ]
         last_iteration_number = max(
             (int(n) for n in number_list if n.isnumeric()), default=0
         )
         if not last_iteration_number:
             raise ValueError(f"No result files found in {job_path}")
-        data_file = job_path / f"run_it{last_iteration_number:03d}_data.star"
-        model_file = job_path / f"run_it{last_iteration_number:03d}_model.star"
-        for check_file in (data_file, model_file):
+        data_file = f"run_it{last_iteration_number:03d}_data.star"
+        model_file = f"run_it{last_iteration_number:03d}_model.star"
+        for check_file in (
+            self._basepath / job_path / data_file,
+            self._basepath / job_path / model_file,
+        ):
             if not check_file.exists():
                 raise ValueError(f"File {check_file} missing from job directory")
         return data_file, model_file

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -49,14 +49,16 @@ class CTFFind(JobType):
     def _load_job_directory(self, jobdir):
         file = self._read_star_file(jobdir, "micrographs_ctf.star")
 
-        astigmatism = self.parse_star_file("_rlnCtfAstigmatism", file, 1)
-        defocus_u = self.parse_star_file("_rlnDefocusU", file, 1)
-        defocus_v = self.parse_star_file("_rlnDefocusV", file, 1)
-        defocus_angle = self.parse_star_file("_rlnDefocusAngle", file, 1)
-        max_resolution = self.parse_star_file("_rlnCtfMaxResolution", file, 1)
-        fig_of_merit = self.parse_star_file("_rlnCtfFigureOfMerit", file, 1)
+        info_table = self._find_table_from_column_name("_rlnCtfAstigmatism", file)
 
-        micrograph_name = self.parse_star_file("_rlnMicrographName", file, 1)
+        astigmatism = self.parse_star_file("_rlnCtfAstigmatism", file, info_table)
+        defocus_u = self.parse_star_file("_rlnDefocusU", file, info_table)
+        defocus_v = self.parse_star_file("_rlnDefocusV", file, info_table)
+        defocus_angle = self.parse_star_file("_rlnDefocusAngle", file, info_table)
+        max_resolution = self.parse_star_file("_rlnCtfMaxResolution", file, info_table)
+        fig_of_merit = self.parse_star_file("_rlnCtfFigureOfMerit", file, info_table)
+
+        micrograph_name = self.parse_star_file("_rlnMicrographName", file, info_table)
 
         micrograph_list = []
         for j in range(len(micrograph_name)):

--- a/src/relion/_parser/jobtype.py
+++ b/src/relion/_parser/jobtype.py
@@ -66,3 +66,9 @@ class JobType(collections.abc.Mapping):
         if not values_list:
             print("Warning - no values found for", loop_name)
         return values_list
+
+    def _find_table_from_column_name(self, cname, star_doc):
+        for block_index, block in enumerate(star_doc):
+            if list(block.find_loop(cname)):
+                return block_index
+        return None

--- a/src/relion/_parser/jobtype.py
+++ b/src/relion/_parser/jobtype.py
@@ -1,0 +1,68 @@
+import collections.abc
+import os
+import functools
+from gemmi import cif
+
+
+class JobType(collections.abc.Mapping):
+    def __eq__(self, other):
+        if isinstance(other, JobType):  # check this
+            return self._basepath == other._basepath
+        return False
+
+    def __hash__(self):
+        return hash(("relion._parser.JobType", self._basepath))
+
+    def __init__(self, path):
+        self._basepath = path
+        self._jobcache = {}
+
+    def __iter__(self):
+        return iter(self.jobs)
+
+    def __len__(self):
+        return len(self.jobs)
+
+    def __repr__(self):
+        return f"JobType({repr(str(self._basepath))})"
+
+    def __str__(self):
+        return f"<JobType parser at {self._basepath}>"
+
+    @property
+    def jobs(self):
+        return sorted(
+            d.name
+            for d in self._basepath.iterdir()
+            if d.is_dir() and not d.is_symlink()
+        )
+
+    def __getitem__(self, key):
+        if not isinstance(key, str):
+            raise KeyError(f"Invalid argument {key!r}, expected string")
+        if key not in self._jobcache:
+            job_path = self._basepath / key
+            if not job_path.is_dir():
+                raise KeyError(
+                    f"no job directory present for {key} in {self._basepath}"
+                )
+            self._jobcache[key] = self._load_job_directory(key)
+        return self._jobcache[key]
+
+    def _load_job_directory(self, jobdir):
+        raise NotImplementedError("Load job directory not implemented")
+
+    @functools.lru_cache(maxsize=None)
+    def _read_star_file(self, job_num, file_name):
+        full_path = self._basepath / job_num / file_name
+        gemmi_readable_path = os.fspath(full_path)
+        star_doc = cif.read_file(gemmi_readable_path)
+        return star_doc
+
+    def parse_star_file(self, loop_name, star_doc, block_number):
+        data_block = star_doc[block_number]
+        values = data_block.find_loop(loop_name)
+        values_list = list(values)
+        if not values_list:
+            print("Warning - no values found for", loop_name)
+        return values_list

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -1,9 +1,5 @@
-import collections.abc
-from gemmi import cif
-
-import os
-import functools
 from collections import namedtuple
+from relion._parser.jobtype import JobType
 
 MCMicrograph = namedtuple(
     "MCMicrograph", ["micrograph_name", "total_motion", "early_motion", "late_motion"]
@@ -18,24 +14,9 @@ MCMicrograph.early_motion.__doc__ = "Early motion."
 MCMicrograph.late_motion.__doc__ = "Late motion."
 
 
-class MotionCorr(collections.abc.Mapping):
-    def __eq__(self, other):
-        if isinstance(other, MotionCorr):
-            return self._basepath == other._basepath
-        return False
-
+class MotionCorr(JobType):
     def __hash__(self):
         return hash(("relion._parser.MotionCorr", self._basepath))
-
-    def __init__(self, path):
-        self._basepath = path
-        self._jobcache = {}
-
-    def __iter__(self):
-        return iter(self.jobs)
-
-    def __len__(self):
-        return len(self.jobs)
 
     def __repr__(self):
         return f"MotionCorr({repr(str(self._basepath))})"
@@ -43,43 +24,8 @@ class MotionCorr(collections.abc.Mapping):
     def __str__(self):
         return f"<MotionCorr parser at {self._basepath}>"
 
-    @property
-    def jobs(self):
-        return sorted(
-            d.stem
-            for d in self._basepath.iterdir()
-            if d.is_dir() and not d.is_symlink()
-        )
-
-    def __getitem__(self, key):
-        if not isinstance(key, str):
-            raise KeyError(f"Invalid argument {key!r}, expected string")
-        if key not in self._jobcache:
-            job_path = self._basepath / key
-            if not job_path.is_dir():
-                raise KeyError(
-                    f"no job directory present for {key} in {self._basepath}"
-                )
-            self._jobcache[key] = self._load_job_directory(key)
-        return self._jobcache[key]
-
-    def parse_star_file(self, loop_name, star_doc, block_number):
-        data_block = star_doc[block_number]
-        values = data_block.find_loop(loop_name)
-        values_list = list(values)
-        if not values_list:
-            print("Warning - no values found for", loop_name)
-        return values_list
-
-    @functools.lru_cache(maxsize=None)
-    def _read_star_file(self, job_num):
-        full_path = self._basepath / job_num / "corrected_micrographs.star"
-        gemmi_readable_path = os.fspath(full_path)
-        star_doc = cif.read_file(gemmi_readable_path)
-        return star_doc
-
     def _load_job_directory(self, jobdir):
-        file = self._read_star_file(jobdir)
+        file = self._read_star_file(jobdir, "corrected_micrographs.star")
         accum_motion_total = self.parse_star_file("_rlnAccumMotionTotal", file, 1)
         accum_motion_late = self.parse_star_file("_rlnAccumMotionLate", file, 1)
         accum_motion_early = self.parse_star_file("_rlnAccumMotionEarly", file, 1)

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -26,10 +26,19 @@ class MotionCorr(JobType):
 
     def _load_job_directory(self, jobdir):
         file = self._read_star_file(jobdir, "corrected_micrographs.star")
-        accum_motion_total = self.parse_star_file("_rlnAccumMotionTotal", file, 1)
-        accum_motion_late = self.parse_star_file("_rlnAccumMotionLate", file, 1)
-        accum_motion_early = self.parse_star_file("_rlnAccumMotionEarly", file, 1)
-        micrograph_name = self.parse_star_file("_rlnMicrographName", file, 1)
+
+        info_table = self._find_table_from_column_name("_rlnAccumMotionTotal", file)
+
+        accum_motion_total = self.parse_star_file(
+            "_rlnAccumMotionTotal", file, info_table
+        )
+        accum_motion_late = self.parse_star_file(
+            "_rlnAccumMotionLate", file, info_table
+        )
+        accum_motion_early = self.parse_star_file(
+            "_rlnAccumMotionEarly", file, info_table
+        )
+        micrograph_name = self.parse_star_file("_rlnMicrographName", file, info_table)
 
         micrograph_list = []
         for j in range(len(micrograph_name)):

--- a/tests/parser/test_class2D.py
+++ b/tests/parser/test_class2D.py
@@ -14,6 +14,16 @@ def class2d(proj):
     return proj.class2D
 
 
+def test_result_of_casting_to_string(class2d, proj):
+    class2d_path = proj.basepath / "Class2D"
+    assert str(class2d) == f"<Class2D parser at {class2d_path}>"
+
+
+def test_class2D_representation(class2d, proj):
+    class2d_path = proj.basepath / "Class2D"
+    assert repr(class2d) == f"Class2D({repr(str(class2d_path))})"
+
+
 def test_list_all_jobs_in_class2d_directory(class2d):
     """
     When used in an iterator context the Class2D instance returns

--- a/tests/parser/test_class3D.py
+++ b/tests/parser/test_class3D.py
@@ -14,6 +14,16 @@ def class3d_object(proj):
     return proj.class3D
 
 
+def test_result_of_casting_to_string(class3d_object, proj):
+    class3d_path = proj.basepath / "Class3D"
+    assert str(class3d_object) == f"<Class3D parser at {class3d_path}>"
+
+
+def test_class3D_representation(class3d_object, proj):
+    class3d_path = proj.basepath / "Class3D"
+    assert repr(class3d_object) == f"Class3D({repr(str(class3d_path))})"
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_aliases_are_dropped_on_iterating_so_jobs_arent_double_counted(proj):
     """

--- a/tests/parser/test_ctffind.py
+++ b/tests/parser/test_ctffind.py
@@ -13,6 +13,16 @@ def ctffind(proj):
     return proj.ctffind
 
 
+def test_result_of_casting_to_string(ctffind, proj):
+    ctffind_path = proj.basepath / "CtfFind"
+    assert str(ctffind) == f"<CTFFind parser at {ctffind_path}>"
+
+
+def test_ctffind_representation(ctffind, proj):
+    ctffind_path = proj.basepath / "CtfFind"
+    assert repr(ctffind) == f"CTFFind({repr(str(ctffind_path))})"
+
+
 def test_list_ctffind_jobs(ctffind):
     assert ctffind
     assert len(ctffind) == 1

--- a/tests/parser/test_motioncorrection.py
+++ b/tests/parser/test_motioncorrection.py
@@ -19,6 +19,16 @@ def invalid_input(dials_data):
     return relion.Project(dials_data("relion_tutorial_data"))
 
 
+def test_result_of_casting_to_string(input, proj):
+    motioncorr_path = proj.basepath / "MotionCorr"
+    assert str(input) == f"<MotionCorr parser at {motioncorr_path}>"
+
+
+def test_motioncorr_representation(input, proj):
+    motioncorr_path = proj.basepath / "MotionCorr"
+    assert repr(input) == f"MotionCorr({repr(str(motioncorr_path))})"
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_aliases_are_dropped_on_iterating_so_jobs_arent_double_counted(proj):
     """


### PR DESCRIPTION
There is a reasonable amount of shared code between the different job type classes which has been refactored into a `JobType` superclass. Each job type extracts information from loops in a star file in a `_load_job_directory` method. The loop number containing the relevant information was hard-coded. To protect against potential changes to star file structure in different Relion releases a method that searches a star file for a given table heading and returns the loop number has been added. Some tests of `repr` and `str` behaviour have also been added.