### PR TITLE
Fixes for LGTM alerts

### DIFF
--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -34,7 +34,7 @@ Class2DParticleClass.overall_fourier_completeness.__doc__ = (
 
 class Class2D(JobType):
     def __eq__(self, other):
-        if isinstance(other, JobType):  # check this
+        if isinstance(other, Class2D):  # check this
             return self._basepath == other._basepath
         return False
 

--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -33,6 +33,11 @@ Class2DParticleClass.overall_fourier_completeness.__doc__ = (
 
 
 class Class2D(JobType):
+    def __eq__(self, other):
+        if isinstance(other, JobType):  # check this
+            return self._basepath == other._basepath
+        return False
+
     def __hash__(self):
         return hash(("relion._parser.Class2D", self._basepath))
 

--- a/src/relion/_parser/class3D.py
+++ b/src/relion/_parser/class3D.py
@@ -33,6 +33,11 @@ Class3DParticleClass.overall_fourier_completeness.__doc__ = (
 
 
 class Class3D(JobType):
+    def __eq__(self, other):
+        if isinstance(other, JobType):  # check this
+            return self._basepath == other._basepath
+        return False
+
     def __hash__(self):
         return hash(("relion._parser.Class3D", self._basepath))
 

--- a/src/relion/_parser/class3D.py
+++ b/src/relion/_parser/class3D.py
@@ -34,7 +34,7 @@ Class3DParticleClass.overall_fourier_completeness.__doc__ = (
 
 class Class3D(JobType):
     def __eq__(self, other):
-        if isinstance(other, JobType):  # check this
+        if isinstance(other, Class3D):  # check this
             return self._basepath == other._basepath
         return False
 

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -33,7 +33,7 @@ CTFMicrograph.fig_of_merit.__doc__ = (
 
 class CTFFind(JobType):
     def __eq__(self, other):
-        if isinstance(other, JobType):  # check this
+        if isinstance(other, CTFFind):  # check this
             return self._basepath == other._basepath
         return False
 

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -32,6 +32,11 @@ CTFMicrograph.fig_of_merit.__doc__ = (
 
 
 class CTFFind(JobType):
+    def __eq__(self, other):
+        if isinstance(other, JobType):  # check this
+            return self._basepath == other._basepath
+        return False
+
     def __hash__(self):
         return hash(("relion._parser.CTFFind", self._basepath))
 

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -16,7 +16,7 @@ MCMicrograph.late_motion.__doc__ = "Late motion."
 
 class MotionCorr(JobType):
     def __eq__(self, other):
-        if isinstance(other, JobType):  # check this
+        if isinstance(other, MotionCorr):  # check this
             return self._basepath == other._basepath
         return False
 

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -15,6 +15,11 @@ MCMicrograph.late_motion.__doc__ = "Late motion."
 
 
 class MotionCorr(JobType):
+    def __eq__(self, other):
+        if isinstance(other, JobType):  # check this
+            return self._basepath == other._basepath
+        return False
+
     def __hash__(self):
         return hash(("relion._parser.MotionCorr", self._basepath))
 

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -97,7 +97,6 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                         logger.info("Sending %s results for %s", item[0], item[1])
                         self.send_results(item[0], item[1])
                         # self.send_motioncorrection_results_to_ispyb(item[0], item[1])
-                        # pass
             except FileNotFoundError:
                 logger.info("No files found for Motion Correction")
 
@@ -114,7 +113,6 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                         # self.send_ctffind_results_to_ispyb(item[0], item[1])
             except FileNotFoundError:
                 logger.info("No files found for CTFFind")
-                # pass
 
             poll = relion_process.poll()  # None value -> process is still running
             print("POLL RELION_RUNNING:", poll)

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -97,7 +97,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                         logger.info("Sending %s results for %s", item[0], item[1])
                         self.send_results(item[0], item[1])
                         # self.send_motioncorrection_results_to_ispyb(item[0], item[1])
-                        pass
+                        # pass
             except FileNotFoundError:
                 logger.info("No files found for Motion Correction")
 
@@ -114,7 +114,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                         # self.send_ctffind_results_to_ispyb(item[0], item[1])
             except FileNotFoundError:
                 logger.info("No files found for CTFFind")
-                pass
+                # pass
 
             poll = relion_process.poll()  # None value -> process is still running
             print("POLL RELION_RUNNING:", poll)


### PR DESCRIPTION
Fixes for the alerts currently raised by LGTM. Removes some `pass` statements from the zocalo wrapper and adds `__eq__` definitions to `JobType` derived classes