### PR TITLE
Remove caching of JobType method to read star files

### DIFF
--- a/src/relion/_parser/jobtype.py
+++ b/src/relion/_parser/jobtype.py
@@ -1,6 +1,5 @@
 import collections.abc
 import os
-import functools
 from gemmi import cif
 
 
@@ -52,7 +51,6 @@ class JobType(collections.abc.Mapping):
     def _load_job_directory(self, jobdir):
         raise NotImplementedError("Load job directory not implemented")
 
-    @functools.lru_cache(maxsize=None)
     def _read_star_file(self, job_num, file_name):
         full_path = self._basepath / job_num / file_name
         gemmi_readable_path = os.fspath(full_path)


### PR DESCRIPTION
Remove the `lru_cache` decorator from the `_read_star_file` method of `JobType`. The way this cache is implemented would mean that if a file is read and then modified it would not be read again, so updates to that file would not be visible. This is undesirable in the context of the zocalo wrapper which should regularly check for updates throughout the runtime of the Relion pipeline. For now remove the cache and if it is desirable to add caching later it can possibly be added with a check on the file time stamp.