### PR TITLE
Change Project to inherit from RelionPipeline and add functionality to collect results by iterating over the Project

### DIFF
--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -37,7 +37,7 @@ class Project(RelionPipeline):
             raise ValueError(f"path {self.basepath} is not a directory")
         try:
             self.load()
-        except Exception:
+        except FileNotFoundError:
             pass
             # raise RuntimeWarning(
             #    f"Relion Project was unable to load the relion pipeline from {self.basepath}/default_pipeline.star"

--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -37,7 +37,7 @@ class Project(RelionPipeline):
             raise ValueError(f"path {self.basepath} is not a directory")
         try:
             self.load()
-        except FileNotFoundError:
+        except (FileNotFoundError, RuntimeError):
             pass
             # raise RuntimeWarning(
             #    f"Relion Project was unable to load the relion pipeline from {self.basepath}/default_pipeline.star"

--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -10,6 +10,7 @@ from relion._parser.motioncorrection import MotionCorr
 from relion._parser.class2D import Class2D
 from relion._parser.class3D import Class3D
 from relion._parser.relion_pipeline import RelionPipeline
+import copy
 
 __all__ = []
 __author__ = "Diamond Light Source - Scientific Software"
@@ -18,7 +19,7 @@ __version__ = "0.2.0"
 __version_tuple__ = tuple(int(x) for x in __version__.split("."))
 
 
-class Project:
+class Project(RelionPipeline):
     """
     Reads information from a Relion project directory and makes it available in
     a structured, object-oriented, and pythonic fashion.
@@ -30,10 +31,18 @@ class Project:
         :param path: A string or file system path object pointing to the root
                      directory of an existing Relion project.
         """
+        super().__init__("Import/job001")
         self.basepath = pathlib.Path(path)
         if not self.basepath.is_dir():
             raise ValueError(f"path {self.basepath} is not a directory")
-        self.pipeline = RelionPipeline("Import/job001")
+        try:
+            self.load()
+        except Exception:
+            pass
+            # raise RuntimeWarning(
+            #    f"Relion Project was unable to load the relion pipeline from {self.basepath}/default_pipeline.star"
+            # )
+        self.res = RelionResults()
 
     def __eq__(self, other):
         if isinstance(other, Project):
@@ -48,6 +57,16 @@ class Project:
 
     def __str__(self):
         return f"<relion.Project at {self.basepath}>"
+
+    @property
+    def _results_dict(self):
+        resd = {
+            "CtfFind": self.ctffind,
+            "MotionCorr": self.motioncorrection,
+            "Class2D": self.class2D,
+            "Class3D": self.class3D,
+        }
+        return resd
 
     @property
     @functools.lru_cache(maxsize=1)
@@ -81,23 +100,92 @@ class Project:
         and lists of Class3DParticleClass namedtuples as values."""
         return Class3D(self.basepath / "Class3D")
 
-    def _load_pipeline(self):
-        self.pipeline.load_nodes_from_star(self.basepath / "default_pipeline.star")
-        self.pipeline.check_job_node_statuses(self.basepath)
-        self.pipeline.collect_job_times(list(self.schedule_files))
+    def load(self):
+        self.load_nodes_from_star(self.basepath / "default_pipeline.star")
+        self.check_job_node_statuses(self.basepath)
+        self.collect_job_times(list(self.schedule_files))
 
     def show_job_nodes(self):
-        self._load_pipeline()
-        self.pipeline.show_job_nodes(self.basepath)
-        # self.pipeline.show_all_nodes()
+        self.load()
+        super().show_job_nodes(self.basepath)
 
     @property
     def schedule_files(self):
         return self.basepath.glob("pipeline*.log")
 
     @property
-    def current_jobs(self):
-        self._load_pipeline()
-        # current_node = self.pipeline.current_job
-        return self.pipeline.current_jobs
-        # return (current_node._path, current_node.attributes["start_time_stamp"], current_node.attributes["job_count"])
+    def results(self):
+        # Project.motioncorrection.fget.cache_clear()
+        self._clear_caches()
+        res = []
+        for jtnode in self:
+            if jtnode.attributes["status"]:
+                res_obj = self._results_dict.get(str(jtnode._path))
+                if res_obj is not None:
+                    res.append(
+                        (
+                            res_obj,
+                            jtnode.attributes["job"],
+                            jtnode.attributes["end_time_stamp"],
+                        )
+                    )
+        self.res.consume(res)
+        return self.res
+
+    @property
+    def current_job(self):
+        self.load()
+        currj = super().current_job
+        if currj is None:
+            return None
+        else:
+            return [n.change_name(self.basepath / n.name) for n in currj]
+
+    @staticmethod
+    def _clear_caches():
+        Project.motioncorrection.fget.cache_clear()
+        Project.ctffind.fget.cache_clear()
+        Project.class2D.fget.cache_clear()
+        Project.class3D.fget.cache_clear()
+
+
+class RelionResults:
+    def __init__(self):
+        self._results = []
+        self._fresh_results = []
+        self._seen_before = []
+        self._fresh_called = False
+        self._cache = {}
+
+    def consume(self, results):
+        self._results = [(r[0], r[1]) for r in results]
+        if not self._fresh_called:
+            self._fresh_results = self._results
+            for r in results:
+                if r[2] not in [p[1] for p in self._seen_before]:
+                    self._cache[r[1]] = []
+                    for single_res in r[0][r[1]]:
+                        self._cache[r[1]].append(r[0].for_cache(single_res))
+                if (r[1], r[2]) not in self._seen_before:
+                    self._seen_before.append((r[1], r[2]))
+        else:
+            self._fresh_results = []
+            results_copy = copy.deepcopy(results)
+            for r in results_copy:
+                if (r[1], r[2]) not in self._seen_before:
+                    current_job_results = list(r[0][r[1]])
+                    for single_res in current_job_results:
+                        if r[0].for_cache(single_res) in self._cache[r[1]]:
+                            r[0][r[1]].remove(single_res)
+                        else:
+                            self._cache[r[1]].append(r[0].for_cache(single_res))
+                    self._fresh_results.append((r[0], r[1]))
+                    self._seen_before.append((r[1], r[2]))
+
+    def __iter__(self):
+        return iter(self._results)
+
+    @property
+    def fresh(self):
+        self._fresh_called = True
+        return iter(self._fresh_results)

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -79,3 +79,7 @@ class CTFFind(JobType):
                 )
             )
         return micrograph_list
+
+    @staticmethod
+    def for_cache(ctfmicrograph):
+        return str(ctfmicrograph.micrograph_name)

--- a/src/relion/_parser/jobtype.py
+++ b/src/relion/_parser/jobtype.py
@@ -70,3 +70,7 @@ class JobType(collections.abc.Mapping):
             if list(block.find_loop(cname)):
                 return block_index
         return None
+
+    @staticmethod
+    def for_cache(element):
+        return None

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -56,3 +56,7 @@ class MotionCorr(JobType):
                 )
             )
         return micrograph_list
+
+    @staticmethod
+    def for_cache(mcmicrograph):
+        return str(mcmicrograph.micrograph_name)

--- a/src/relion/_parser/processnode.py
+++ b/src/relion/_parser/processnode.py
@@ -45,6 +45,13 @@ class ProcessNode:
             return True
         return False
 
+    @property
+    def name(self):
+        return str(self._path)
+
+    def change_name(self, new_name):
+        self._path = new_name
+
     def link_to(self, next_node):
         if next_node not in self._out:
             self._out.append(next_node)


### PR DESCRIPTION
`Project` now inherits from `RelionPipeline`. This allows the project to be iterated over to give all scheduled Relion jobs. A helper class has been added that caches job results and can be set to only return results that have not been seen before.