### PR TITLE
Fix entry point declarations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,13 @@ python_requires = >=3.6
 zip_safe = False
 
 [options.entry_points]
+console_scripts =
+    relipy.job = relion.cli.current_job:run
+    relipy.show = relion.cli.pipeline_viewer:run
 libtbx.precommit =
     relion = relion
-zocalo.wrappers = 
-	relion = relion.zocalo.wrapper:RelionWrapper
+zocalo.wrappers =
+    relion = relion.zocalo.wrapper:RelionWrapper
 
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,6 @@
 
 import setuptools
 
-console_scripts = [
-    "relipy.show=relion.cli.pipeline_viewer:run",
-    "relipy.job=relion.cli.current_job:run",
-]
-
 if __name__ == "__main__":
-    setuptools.setup(
-        entry_points={"console_scripts": console_scripts},
-    )
+    # Do not add any parameters here. Edit setup.cfg instead.
+    setuptools.setup()


### PR DESCRIPTION
All package declarations happen inside `setup.cfg`,
`setup.py` is just a tiny piece of code to make `setup.cfg` happen.