### PR TITLE
Change zocalo wrapper to only collect results that have not already been sent

### DIFF
--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -133,13 +133,15 @@ class Project(RelionPipeline):
         return self.res
 
     @property
-    def current_job(self):
+    def current_jobs(self):
         self.load()
-        currj = super().current_job
+        currj = super().current_jobs
         if currj is None:
             return None
         else:
-            return [n.change_name(self.basepath / n.name) for n in currj]
+            for n in currj:
+                n.change_name(self.basepath / n.name)
+            return currj
 
     @staticmethod
     def _clear_caches():

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -197,7 +197,7 @@ def ispyb_results(relion_stage_object, job_string: str):
     representing a single job directory) and translates them into ISPyB
     service commands.
     """
-    raise ValueError(f"{relion_stage_object!r} is not a known Relion object")
+    return []
 
 
 @ispyb_results.register(relion.CTFFind)

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -190,7 +190,7 @@ def ispyb_results(relion_stage_object, job_string: str):
     representing a single job directory) and translates them into ISPyB
     service commands.
     """
-    return []
+    raise ValueError(f"{relion_stage_object!r} is not a known Relion object")
 
 
 @ispyb_results.register(relion.CTFFind)
@@ -231,4 +231,24 @@ def _(stage_object: relion.MotionCorr, job_string: str):
                 ),  # / number of frames
             }
         )
+    return ispyb_command_list
+
+
+@ispyb_results.register(relion.Class2D)
+def _(stage_object: relion.Class2D, job_string: str):
+    logger.warning(
+        "There are currently no ISPyB commands for the 2D classification stage %s ",
+        job_string,
+    )
+    ispyb_command_list = []
+    return ispyb_command_list
+
+
+@ispyb_results.register(relion.Class3D)
+def _(stage_object: relion.Class3D, job_string: str):
+    logger.warning(
+        "There are currently no ISPyB commands for the 3D classification stage %s ",
+        job_string,
+    )
+    ispyb_command_list = []
     return ispyb_command_list

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -80,8 +80,6 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         ]:
             time.sleep(1)
 
-            self.check_synchweb_stop()
-
             logger.info("Looking for results")
 
             ispyb_command_list = []
@@ -167,18 +165,6 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
     def create_synchweb_stop_file(self):
         pathlib.Path(self.params["stop_file"]).touch()
-
-    def check_synchweb_stop(self):
-        if pathlib.Path(self.params["stop_file"]).is_file():
-            self.fail_relion()
-
-    def fail_relion(self):
-        for job in self.relion_prj.current_jobs:
-            try:
-                (job.name / "RELION_JOB_EXIT_SUCCESS").unlink()
-            except FileNotFoundError:
-                pass
-            (job.name / "RELION_JOB_EXIT_FAILURE").touch()
 
     def get_status(self, job_path):
         relion_stop_files = [

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -74,9 +74,9 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         )
         self._relion_subthread.start()
 
-        self.relion_prj = relion.Project(self.working_directory)
+        relion_prj = relion.Project(self.working_directory)
         while self._relion_subthread.is_alive() and False not in [
-            n.attributes["status"] for n in self.relion_prj
+            n.attributes["status"] for n in relion_prj
         ]:
             time.sleep(1)
 
@@ -84,9 +84,9 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
             ispyb_command_list = []
 
-            self.relion_prj.load()
+            relion_prj.load()
             # Should only return results that have not previously been sent
-            for fr in self.relion_prj.results.fresh:
+            for fr in relion_prj.results.fresh:
                 ispyb_command_list.extend(ispyb_results(fr[0], fr[1]))
                 logger.info(f"Fresh results found for {fr[1]}")
 


### PR DESCRIPTION
The separate calls to `CTFFind` and `MotionCorr` have been replaced with a loop over `relion_proj.results.fresh` which should just return results that have not been seen before from jobs that have posted a success, as a (Relion stage object, job name) pair. (Note that this has not been extensively tested for correct behaviour.) In order to collect the necessary information `relion_proj.load()` has to be run inside the results collection loop. 

I have also added a check on whether any Relion job failures have been posted before results collection is done. We may have situations where we still want to collect results after a failure has posted so this may need to be moved to a later point or removed but it demonstrates how to do this kind of check. 

I changed the default behaviour of `ispyb_results` to return an empty list rather than raise an exception as there may now be cases where a Class2D or Class3D Relion stage object may be encountered which we don't want to cause a crash.