### PR TITLE
Make some changes so that the wrapper runs up to CTF estimation

### DIFF
--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -100,7 +100,11 @@ class Project(RelionPipeline):
         and lists of Class3DParticleClass namedtuples as values."""
         return Class3D(self.basepath / "Class3D")
 
+    def origin_present(self):
+        return (self.basepath / self.origin).is_dir()
+
     def load(self):
+        self._jobs_collapsed = False
         self.load_nodes_from_star(self.basepath / "default_pipeline.star")
         self.check_job_node_statuses(self.basepath)
         self.collect_job_times(list(self.schedule_files))
@@ -177,10 +181,13 @@ class RelionResults:
                 if (r[1], r[2]) not in self._seen_before:
                     current_job_results = list(r[0][r[1]])
                     for single_res in current_job_results:
+                        if self._cache.get(r[1]) is None:
+                            self._cache[r[1]] = []
                         if r[0].for_cache(single_res) in self._cache[r[1]]:
                             r[0][r[1]].remove(single_res)
                         else:
                             self._cache[r[1]].append(r[0].for_cache(single_res))
+
                     self._fresh_results.append((r[0], r[1]))
                     self._seen_before.append((r[1], r[2]))
 

--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -2698,6 +2698,16 @@ def run_pipeline(opts):
             preprocess_schedule_name = PREPROCESS_SCHEDULE_PASS1
         else:
             preprocess_schedule_name = PREPROCESS_SCHEDULE_PASS2
+
+        RunJobs(
+            runjobs,
+            1,
+            1,
+            preprocess_schedule_name,
+        )
+
+        WaitForJob(runjobs[-1], 30)
+
         RunJobs(
             runjobs,
             opts.preprocess_repeat_times,

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -75,6 +75,12 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         self._relion_subthread.start()
 
         relion_prj = relion.Project(self.working_directory)
+
+        while self._relion_subthread.is_alive() and not relion_prj.origin_present():
+            time.sleep(0.5)
+
+        relion_prj.load()
+
         while self._relion_subthread.is_alive() and False not in [
             n.attributes["status"] for n in relion_prj
         ]:
@@ -85,6 +91,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
             ispyb_command_list = []
 
             relion_prj.load()
+
             # Should only return results that have not previously been sent
             for fr in relion_prj.results.fresh:
                 ispyb_command_list.extend(ispyb_results(fr[0], fr[1]))
@@ -101,6 +108,10 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
         logger.info("Done.")
         success = True
+
+        if (self.results_directory / "RUNNING_PIPELINER_PREPROCESS").is_file():
+            os.remove(self.results_directory / "RUNNING_PIPELINER_PREPROCESS")
+
         return success
 
     def start_pseudo_relion(self):


### PR DESCRIPTION
Fixed some results caching bugs, stop all Relion processes before the wrapper exits by deleting `RUNNING_PIPELINER_PREPROCESS` and  wait for Relion `Import` job to finish before starting to look for results.