### PR TITLE
Make the function that checks if the Relion Import job is present also check that something appears in the pipeline file

### DIFF
--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -101,6 +101,10 @@ class Project(RelionPipeline):
         return Class3D(self.basepath / "Class3D")
 
     def origin_present(self):
+        try:
+            self.load_nodes_from_star(self.basepath / "default_pipeline.star")
+        except TypeError:
+            return False
         return (self.basepath / self.origin).is_dir()
 
     def load(self):


### PR DESCRIPTION
Check that the `default_pipeline.star` file can be loaded inside `Project.origin_present()`. I suspect that the wrapper is crashing because there is a slight delay in writing information to `default_pipeline.star` and this extra check should make sure that that has happened before proceeding to attempting to collect resutls.