### PR TITLE
Wrapper runs until RUNNING_PIPELINER_PREPROCESS is deleted and cryolo_relion_it.run has finished

### DIFF
--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -2701,15 +2701,6 @@ def run_pipeline(opts):
 
         RunJobs(
             runjobs,
-            1,
-            1,
-            preprocess_schedule_name,
-        )
-
-        WaitForJob(runjobs[-1], 30)
-
-        RunJobs(
-            runjobs,
             opts.preprocess_repeat_times,
             opts.preprocess_repeat_wait,
             preprocess_schedule_name,

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -129,7 +129,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         success = True
 
         if preprocess_check.is_file():
-            os.remove(preprocess_check)
+            preprocess_check.unlink()
 
         return success
 

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -73,6 +73,8 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         )
         self._relion_subthread.start()
 
+        relion_start_time = time.time()
+
         relion_prj = relion.Project(self.working_directory)
 
         while self._relion_subthread.is_alive() and not relion_prj.origin_present():
@@ -115,6 +117,11 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                     "ispyb", {"ispyb_command_list": ispyb_command_list}
                 )
                 logger.info("Sent %d commands to ISPyB", len(ispyb_command_list))
+
+            # if Relion has been running too long stop loop of preprocessing jobs
+            # setting this time to 2 minutes for testing - will need to change
+            if time.time() - relion_start_time > 2 * 60:
+                preprocess_check.unlink()
 
         logger.info("Done.")
         success = True

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -85,10 +85,8 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         preprocess_check = self.results_directory / "RUNNING_PIPELINER_PREPROCESS"
 
         while (
-            self._relion_subthread.is_alive()
-            and preprocess_check.is_file()
-            and False not in [n.attributes["status"] for n in relion_prj]
-        ):
+            self._relion_subthread.is_alive() or preprocess_check.is_file()
+        ) and False not in [n.attributes["status"] for n in relion_prj]:
             time.sleep(1)
 
             logger.info("Looking for results")

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -80,9 +80,13 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
         relion_prj.load()
 
-        while self._relion_subthread.is_alive() and False not in [
-            n.attributes["status"] for n in relion_prj
-        ]:
+        preprocess_check = self.results_directory / "RUNNING_PIPELINER_PREPROCESS"
+
+        while (
+            self._relion_subthread.is_alive()
+            and preprocess_check.is_file()
+            and False not in [n.attributes["status"] for n in relion_prj]
+        ):
             time.sleep(1)
 
             logger.info("Looking for results")
@@ -113,8 +117,8 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         logger.info("Done.")
         success = True
 
-        if (self.results_directory / "RUNNING_PIPELINER_PREPROCESS").is_file():
-            os.remove(self.results_directory / "RUNNING_PIPELINER_PREPROCESS")
+        if preprocess_check.is_file():
+            os.remove(preprocess_check)
 
         return success
 

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -73,8 +73,6 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         )
         self._relion_subthread.start()
 
-        relion_start_time = time.time()
-
         relion_prj = relion.Project(self.working_directory)
 
         while self._relion_subthread.is_alive() and not relion_prj.origin_present():
@@ -118,7 +116,13 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
             # if Relion has been running too long stop loop of preprocessing jobs
             # setting this time to 2 minutes for testing - will need to change
-            if time.time() - relion_start_time > 2 * 60:
+            most_recent_movie = max(
+                [
+                    p.stat().st_mtime
+                    for p in pathlib.Path(self.params["image_directory"]).glob("**/*")
+                ]
+            )
+            if time.time() - most_recent_movie > 30 * 60:
                 preprocess_check.unlink()
 
         logger.info("Done.")

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -97,6 +97,8 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                 relion_prj.load()
                 for job_path in relion_prj._job_nodes:
                     pathlib.Path(job_path.name / "RELION_EXIT_ABORTED").touch()
+                for p in self.results_directory.glob("RUNNING_*"):
+                    p.unlink()
 
             relion_prj.load()
 


### PR DESCRIPTION
The wrapper should now run while the `RUNNING_PIPELINER_PREPROCESS` file exists or `cryolo_relion_it.run` is alive. A timeout has been added: when a certain time has elapsed from when Relion was started the `RUNNING_PIPELINER_PREPROCESS` file is deleted. For testing I have hardcoded this to be 2 minutes (clearly not enough in real circumstances). We may want to make this adjustable by putting it in the wrapper somehow, or by triggering the timeout based on session end time.