### PR TITLE
Small fix to account for empty lists of star values.

### DIFF
--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -105,6 +105,8 @@ class Project(RelionPipeline):
             self.load_nodes_from_star(self.basepath / "default_pipeline.star")
         except (TypeError, FileNotFoundError, RuntimeError):
             return False
+        if len(self._nodes) == 0:
+            return False
         return (self.basepath / self.origin / "RELION_JOB_EXIT_SUCCESS").is_file()
 
     def load(self):

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -41,6 +41,9 @@ class RelionPipeline:
         for block_index, block in enumerate(star_doc):
             if list(block.find_loop(search)):
                 block_number = block_index
+                break
+        else:
+            return []
         data_block = star_doc[block_number]
         values = data_block.find_loop(column)
         return list(values)


### PR DESCRIPTION
Stop the pipeline breaking if it gets an empty list from reading a star file.