### PR TITLE
Check for the presence of the Relion lock directory before accessing default_pipeline.star

### DIFF
--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -313,10 +313,10 @@ class RelionPipeline:
 
 class DummyLock:
     def __init__(self):
-        pass
+        self.failed = True
 
     def __enter__(self):
-        pass
+        return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         raise NotImplementedError(


### PR DESCRIPTION
Use a context manager to check for the presence of the `.relion_lock` directory before accessing the `default_pipeline.star` file. If it doesn't exist create it and remove it once the file has been read. If it does exist wait and try again; timeout after 20 attempts and store the information that there was a failure in the context manager. The method that reads the star file may then check for this failure and return an empty `Document` object instead of attempting to read the file. In the case of a failure the lock directory will not be removed on exit. Some restructuring has been done so that this lock is only applied when the file is actually being read and to allow the necessary information on which files to lock for to be passed from the `Project` class to the `RelionPipeline` class where the star file reading is done.