### PR TITLE
Make sure postprocessing jobs are not stopped immediately which was causing the wrapper to exit early

### DIFF
--- a/src/relion/_parser/processgraph.py
+++ b/src/relion/_parser/processgraph.py
@@ -95,6 +95,8 @@ class ProcessGraph(collections.abc.Sequence):
             return False
 
     def split_connected(self):
+        if len(self._node_list) == 0:
+            return []
         connected_graphs = []
         for origin in self.find_origins():
             curr_graph = []

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -157,6 +157,9 @@ class RelionPipeline:
 
     def _collapse_jobs_to_jobtypes(self):
         ordered_graph = []
+        if len(self._nodes) == 0:
+            self._jobtype_nodes = ProcessGraph([])
+            return
         self._job_nodes.node_explore(
             self._job_nodes[self._job_nodes.index(self.origin)], ordered_graph
         )

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -136,6 +136,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
             if (
                 currtime - most_recent_movie > 30 * 60
                 and currtime - relion_started > 10 * 60
+                and preprocess_check.is_file()
             ):
                 preprocess_check.unlink()
 

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -81,6 +81,8 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         )
         self._relion_subthread.start()
 
+        relion_started = time.time()
+
         relion_prj = relion.Project(self.working_directory)
 
         while self._relion_subthread.is_alive() and not relion_prj.origin_present():
@@ -130,7 +132,11 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                     for p in pathlib.Path(self.params["image_directory"]).glob("**/*")
                 ]
             )
-            if time.time() - most_recent_movie > 30 * 60:
+            currtime = time.time()
+            if (
+                currtime - most_recent_movie > 30 * 60
+                and currtime - relion_started > 10 * 60
+            ):
                 preprocess_check.unlink()
 
         logger.info("Done.")

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -83,14 +83,16 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
         relion_started = time.time()
 
+        preprocess_check = self.results_directory / "RUNNING_PIPELINER_PREPROCESS"
+
         relion_prj = relion.Project(self.working_directory)
 
-        while self._relion_subthread.is_alive() and not relion_prj.origin_present():
+        while not relion_prj.origin_present() or not preprocess_check.is_file():
             time.sleep(0.5)
+            if time.time() - relion_started > 10 * 60:
+                break
 
         relion_prj.load()
-
-        preprocess_check = self.results_directory / "RUNNING_PIPELINER_PREPROCESS"
 
         while (
             self._relion_subthread.is_alive() or preprocess_check.is_file()

--- a/tests/parser/test_processgraph.py
+++ b/tests/parser/test_processgraph.py
@@ -179,6 +179,12 @@ def test_process_graph_split_connected(graph, new_origin_graph):
     assert connected == [graph_snapshot, ProcessGraph([new_node])]
 
 
+def test_process_graph_split_connected_without_any_nodes():
+    empty_graph = ProcessGraph([])
+    connected = empty_graph.split_connected()
+    assert len(connected) == 0
+
+
 @mock.patch("relion._parser.processgraph.Digraph")
 def test_process_graph_show_all_nodes(mock_Digraph, graph):
     graph.show_all_nodes()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -48,3 +48,9 @@ def test_Project_schedule_files_property_contains_the_correct_files(dials_data, 
         pathlib.Path(dials_data("relion_tutorial_data")) / "pipeline_CLASS3D.log"
         in proj.schedule_files
     )
+
+
+def test_results_collection_does_not_crash_for_an_empty_project():
+    proj = relion.Project("./")
+    results = proj.results
+    assert results._results == []


### PR DESCRIPTION
In #85 a timeout was applied that stopped preprocessing jobs if the last image file is more than 30 minutes old. In the case where processing is done on an old data collection this leads to an earlier exit than is desirable as the preprocessing jobs are stopped quickly and the wrapper may exit without results collection. Here it is required that `cryolo_relion_it` has been running for 10 minutes before the preprocessing jobs can be stopped.

Some changes are also made to reduce the number of times the `default_pipeline.star` file is accessed (which should remove a race condition arising from the fact that we sometimes want those calls to be reading the same star file data) and to stop `_calculate_relative_job_times` from crashing if there are no registered jobs.