### PR TITLE
Ensure that preprocessing jobs are not stopped before they have all run at least once

### DIFF
--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -122,7 +122,7 @@ class Project(RelionPipeline):
         self._jobs_collapsed = False
         self.load_nodes_from_star(self.basepath / "default_pipeline.star")
         self.check_job_node_statuses(self.basepath)
-        self.collect_job_times(list(self.schedule_files))
+        self.collect_job_times(list(self.schedule_files), "pipeline_PREPROCESS.log")
 
     def show_job_nodes(self):
         self.load()

--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -122,7 +122,9 @@ class Project(RelionPipeline):
         self._jobs_collapsed = False
         self.load_nodes_from_star(self.basepath / "default_pipeline.star")
         self.check_job_node_statuses(self.basepath)
-        self.collect_job_times(list(self.schedule_files), "pipeline_PREPROCESS.log")
+        self.collect_job_times(
+            list(self.schedule_files), self.basepath / "pipeline_PREPROCESS.log"
+        )
 
     def show_job_nodes(self):
         self.load()

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -33,9 +33,6 @@ class RelionPipeline:
             self._collapse_jobs_to_jobtypes()
         return iter(self._jobtype_nodes)
 
-    def __len__(self):
-        return len(self._jobtype_nodes)
-
     @property
     def _plock(self):
         return DummyLock()

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -275,7 +275,9 @@ class RelionPipeline:
                         print(line.split()[1])
                         joblist.append(
                             self._job_nodes[
-                                self._job_nodes.index(pathlib.Path(line.split()[1]))
+                                self._job_nodes.index(
+                                    pathlib.PurePosixPath(line.split()[1])
+                                )
                             ]
                         )
         return joblist

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -272,7 +272,6 @@ class RelionPipeline:
             with open(logfile, "r") as lfile:
                 for line in lfile.readlines():
                     if line.startswith(" - "):
-                        print(line.split()[1])
                         joblist.append(
                             self._job_nodes[
                                 self._job_nodes.index(

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -33,6 +33,9 @@ class RelionPipeline:
             self._collapse_jobs_to_jobtypes()
         return iter(self._jobtype_nodes)
 
+    def __len__(self):
+        return len(self._jobtype_nodes)
+
     @property
     def _plock(self):
         return DummyLock()

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -141,7 +141,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
             if len(relion_prj) != 0:
                 for job in relion_prj.preprocess:
                     if (
-                        datetime.timestamp(job.attributes["start_time_stamp"])
+                        datetime.datetime.timestamp(job.attributes["start_time_stamp"])
                         > most_recent_movie
                         and job.attributes["job_count"] >= 1
                     ):

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -138,7 +138,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                 ]
             )
 
-            if len(relion_prj) != 0:
+            if len(relion_prj._job_nodes) != 0:
                 for job in relion_prj.preprocess:
                     if (
                         datetime.datetime.timestamp(job.attributes["start_time_stamp"])

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -1,3 +1,4 @@
+import datetime
 import enum
 import functools
 import logging
@@ -94,6 +95,8 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
         relion_prj.load()
 
+        preproc_recently_run = False
+
         while (
             self._relion_subthread.is_alive() or preprocess_check.is_file()
         ) and False not in [n.attributes["status"] for n in relion_prj]:
@@ -134,11 +137,23 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                     for p in pathlib.Path(self.params["image_directory"]).glob("**/*")
                 ]
             )
+
+            if len(relion_prj) != 0:
+                for job in relion_prj.preprocess:
+                    if (
+                        datetime.timestamp(job.attributes["start_time_stamp"])
+                        > most_recent_movie
+                        and job.attributes["job_count"] >= 1
+                    ):
+                        preproc_recently_run = True
+                        break
+
             currtime = time.time()
             if (
                 currtime - most_recent_movie > 30 * 60
                 and currtime - relion_started > 10 * 60
                 and preprocess_check.is_file()
+                and preproc_recently_run
             ):
                 preprocess_check.unlink()
 

--- a/tests/parser/test_relion_pipeline.py
+++ b/tests/parser/test_relion_pipeline.py
@@ -136,3 +136,14 @@ def test_relion_pipeline_current_jobs_property_with_timing_info_multiple_jobs(
         "MotionCorr/job002",
         "LocalRes/job031",
     ]
+
+
+def test_get_pipeline_jobs_from_preprocess_log_file(dials_data):
+    pipeline = RelionPipeline("Import/job001")
+    pipeline.load_nodes_from_star(
+        dials_data("relion_tutorial_data") / "default_pipeline.star"
+    )
+    preproc_jobs = pipeline._get_pipeline_jobs(
+        dials_data("relion_tutorial_data") / "pipeline_PREPROCESS.log"
+    )
+    assert "MotionCorr/job002" in preproc_jobs


### PR DESCRIPTION
Currently the 10 minutes after Relion started + 30 minutes after last `Movies` file timeout for deleting `RUNNING_PIPELINER_PREPROCESS` sometimes leads to preprocessing jobs being stopped before they have all completed. It is now required that all preprocessing jobs have run at least once and that all have a last start time that is after the most recent `Movies` file was created before the preprocessing pipeline can be stopped. To do this information from the preprocessing log file is used. 