### PR TITLE
Stop Relion processing if there are no currently running jobs and no jobs have been submitted for 10 minutes

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 bump2version==1.0.1
-dials_data==2.1.40
+dials_data==2.1.45
 gemmi==0.4.5
 graphviz==0.16
 pip==21.0.1

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -269,19 +269,18 @@ class RelionPipeline:
         self.preprocess = self._get_pipeline_jobs(preproc_log)
 
     def _get_pipeline_jobs(self, logfile):
-        joblist = []
-        if logfile is not None and logfile.is_file():
+        if logfile is None:
+            return []
+        if logfile.is_file():
             with open(logfile, "r") as lfile:
-                for line in lfile.readlines():
-                    if line.startswith(" - "):
-                        joblist.append(
-                            self._job_nodes[
-                                self._job_nodes.index(
-                                    pathlib.PurePosixPath(line.split()[1])
-                                )
-                            ]
-                        )
-        return joblist
+                return [
+                    self._job_nodes[
+                        self._job_nodes.index(pathlib.PurePosixPath(line.split()[1]))
+                    ]
+                    for line in lfile
+                    if line.startswith(" - ")
+                ]
+        return []
 
     def _calculate_relative_job_times(self):
         times = [j.attributes["start_time_stamp"] for j in self._job_nodes]

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -258,7 +258,9 @@ class RelionPipeline:
                     digraph.edge(nodename, next_nodename, label="??? / ???")
         digraph.render(basepath / "Pipeline" / "relion_pipeline_jobs.gv")
 
-    def collect_job_times(self, schedule_logs, preproc_log=None):
+    def collect_job_times(
+        self, schedule_logs, preproc_log=None, class2d_log=None, class3d_log=None
+    ):
         for job in self._job_nodes:
             jtime, jcount = self._lookup_job_time(schedule_logs, job)
             job.attributes["start_time_stamp"] = jtime
@@ -268,7 +270,7 @@ class RelionPipeline:
 
     def _get_pipeline_jobs(self, logfile):
         joblist = []
-        if logfile is not None:
+        if logfile is not None and logfile.is_file():
             with open(logfile, "r") as lfile:
                 for line in lfile.readlines():
                     if line.startswith(" - "):

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -258,9 +258,7 @@ class RelionPipeline:
                     digraph.edge(nodename, next_nodename, label="??? / ???")
         digraph.render(basepath / "Pipeline" / "relion_pipeline_jobs.gv")
 
-    def collect_job_times(
-        self, schedule_logs, preproc_log=None, class2d_log=None, class3d_log=None
-    ):
+    def collect_job_times(self, schedule_logs, preproc_log=None):
         for job in self._job_nodes:
             jtime, jcount = self._lookup_job_time(schedule_logs, job)
             job.attributes["start_time_stamp"] = jtime

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -236,15 +236,11 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         if len(proj._job_nodes) == 0 or None in [j.attributes["status"] for j in proj]:
             return False
         check_time = time.time()
-        if all(
-            [
-                check_time - datetime.datetime.timestamp(j.attributes["end_time_stamp"])
-                > 10 * 60
-                for j in proj
-            ]
-        ):
-            return True
-        return False
+        return all(
+            check_time - datetime.datetime.timestamp(j.attributes["end_time_stamp"])
+            > 10 * 60
+            for j in proj
+        )
 
     def create_synchweb_stop_file(self):
         pathlib.Path(self.params["stop_file"]).touch()

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -233,12 +233,12 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         return success
 
     def check_whether_ended(self, proj):
-        if len(proj._job_nodes) == 0 or None in [j.attributes["success"] for j in proj]:
+        if len(proj._job_nodes) == 0 or None in [j.attributes["status"] for j in proj]:
             return False
         check_time = time.time()
         if all(
             [
-                datetime.datetime.timestamp(j.attributes["end_time_stamp"]) - check_time
+                check_time - datetime.datetime.timestamp(j.attributes["end_time_stamp"])
                 > 10 * 60
                 for j in proj
             ]

--- a/tests/parser/test_relion_pipeline.py
+++ b/tests/parser/test_relion_pipeline.py
@@ -3,6 +3,7 @@ from relion._parser.processnode import ProcessNode
 from relion._parser.processgraph import ProcessGraph
 from relion._parser.relion_pipeline import RelionPipeline
 import pathlib
+import sys
 
 
 @pytest.fixture
@@ -138,16 +139,13 @@ def test_relion_pipeline_current_jobs_property_with_timing_info_multiple_jobs(
     ]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_get_pipeline_jobs_from_preprocess_log_file(dials_data):
     pipeline = RelionPipeline("Import/job001")
     pipeline.load_nodes_from_star(
         dials_data("relion_tutorial_data") / "default_pipeline.star"
     )
     preproc_jobs = pipeline._get_pipeline_jobs(
-        pathlib.PosixPath(
-            pathlib.PurePosixPath(
-                dials_data("relion_tutorial_data") / "pipeline_PREPROCESS.log"
-            )
-        )
+        pathlib.Path(dials_data("relion_tutorial_data") / "pipeline_PREPROCESS.log")
     )
     assert "MotionCorr/job002" in preproc_jobs

--- a/tests/parser/test_relion_pipeline.py
+++ b/tests/parser/test_relion_pipeline.py
@@ -145,7 +145,9 @@ def test_get_pipeline_jobs_from_preprocess_log_file(dials_data):
     )
     preproc_jobs = pipeline._get_pipeline_jobs(
         pathlib.PosixPath(
-            dials_data("relion_tutorial_data") / "pipeline_PREPROCESS.log"
+            pathlib.PurePosixPath(
+                dials_data("relion_tutorial_data") / "pipeline_PREPROCESS.log"
+            )
         )
     )
     assert "MotionCorr/job002" in preproc_jobs

--- a/tests/parser/test_relion_pipeline.py
+++ b/tests/parser/test_relion_pipeline.py
@@ -144,6 +144,8 @@ def test_get_pipeline_jobs_from_preprocess_log_file(dials_data):
         dials_data("relion_tutorial_data") / "default_pipeline.star"
     )
     preproc_jobs = pipeline._get_pipeline_jobs(
-        dials_data("relion_tutorial_data") / "pipeline_PREPROCESS.log"
+        pathlib.PosixPath(
+            dials_data("relion_tutorial_data") / "pipeline_PREPROCESS.log"
+        )
     )
     assert "MotionCorr/job002" in preproc_jobs

--- a/tests/parser/test_relion_pipeline.py
+++ b/tests/parser/test_relion_pipeline.py
@@ -146,6 +146,6 @@ def test_get_pipeline_jobs_from_preprocess_log_file(dials_data):
         dials_data("relion_tutorial_data") / "default_pipeline.star"
     )
     preproc_jobs = pipeline._get_pipeline_jobs(
-        pathlib.Path(dials_data("relion_tutorial_data") / "pipeline_PREPROCESS.log")
+        dials_data("relion_tutorial_data", pathlib=True) / "pipeline_PREPROCESS.log"
     )
     assert "MotionCorr/job002" in preproc_jobs


### PR DESCRIPTION
If there are no jobs currently running ("running jobs" are here taken to be jobs that have started according to the log files but not posted a success or failure) and no jobs were submitted in the last 10 minutes then delete the `RUNNING_RELION_IT` file to stop the pipeline. This then allows the wrapper to exit. As things currently are the wrapper waits for `cryolo_relion_it` to stop running which may rely on the manual deletion of the RUNNING file.