### PR TITLE
Use a latest movie timeout defined in the recipe rather than hard-coding it

### DIFF
--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -155,7 +155,8 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
             currtime = time.time()
             if (
-                currtime - most_recent_movie > 30 * 60
+                currtime - most_recent_movie
+                > int(self.params["latest_movie_timeout"]) * 60
                 and currtime - relion_started > 10 * 60
                 and preprocess_check.is_file()
                 and preproc_recently_run
@@ -164,7 +165,8 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
             processing_ended = self.check_whether_ended(relion_prj)
             if (
-                currtime - most_recent_movie > 30 * 60
+                currtime - most_recent_movie
+                > int(self.params["latest_movie_timeout"]) * 60
                 and currtime - relion_started > 10 * 60
                 and all_process_check.is_file()
                 and processing_ended


### PR DESCRIPTION
At the moment processing is stopped once all scheduled jobs have completed once and there have been no new micrograph uploads in the last 30 minutes. This time needs extending. The precise amount of time before timeout is not yet precisely specified and is liable to change. To avoid needing to change this hard-coded behaviour in this repository the timeout parameter can be added to the recipe and accessed by the wrapper. This will come with a corresponding change to the relion recipe.