### PR TITLE
Fix race condition relating to Relion SUCCESS files

### DIFF
--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -129,21 +129,33 @@ class RelionPipeline:
             success = basepath / node._path / "RELION_JOB_EXIT_SUCCESS"
             failure = basepath / node._path / "RELION_JOB_EXIT_FAILURE"
             aborted = basepath / node._path / "RELION_JOB_EXIT_ABORTED"
+            # the try/except blocks below catch the case where Relion removes
+            # the SUCCESS/FAILURE file in between checking for its existence
+            # and checking its modification time
             if failure.is_file():
                 node.attributes["status"] = False
-                node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
-                    failure.stat().st_ctime
-                )
+                try:
+                    node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
+                        failure.stat().st_ctime
+                    )
+                except FileNotFoundError:
+                    node.attributes["status"] = None
             elif aborted.is_file():
                 node.attributes["status"] = False
-                node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
-                    aborted.stat().st_ctime
-                )
+                try:
+                    node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
+                        aborted.stat().st_ctime
+                    )
+                except FileNotFoundError:
+                    node.attributes["status"] = None
             elif success.is_file():
                 node.attributes["status"] = True
-                node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
-                    success.stat().st_ctime
-                )
+                try:
+                    node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
+                        success.stat().st_ctime
+                    )
+                except FileNotFoundError:
+                    node.attributes["status"] = None
             else:
                 node.attributes["status"] = None
 

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -137,7 +137,7 @@ class RelionPipeline:
                     failure.stat().st_ctime
                 )
                 node.attributes["status"] = False
-                return
+                continue
             except FileNotFoundError:
                 pass
             try:
@@ -145,7 +145,7 @@ class RelionPipeline:
                     aborted.stat().st_ctime
                 )
                 node.attributes["status"] = False
-                return
+                continue
             except FileNotFoundError:
                 pass
             try:
@@ -153,7 +153,7 @@ class RelionPipeline:
                     success.stat().st_ctime
                 )
                 node.attributes["status"] = True
-                return
+                continue
             except FileNotFoundError:
                 pass
             node.attributes["status"] = None

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -132,32 +132,31 @@ class RelionPipeline:
             # the try/except blocks below catch the case where Relion removes
             # the SUCCESS/FAILURE file in between checking for its existence
             # and checking its modification time
-            if failure.is_file():
+            try:
+                node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
+                    failure.stat().st_ctime
+                )
                 node.attributes["status"] = False
-                try:
-                    node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
-                        failure.stat().st_ctime
-                    )
-                except FileNotFoundError:
-                    node.attributes["status"] = None
-            elif aborted.is_file():
+                return
+            except FileNotFoundError:
+                pass
+            try:
+                node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
+                    aborted.stat().st_ctime
+                )
                 node.attributes["status"] = False
-                try:
-                    node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
-                        aborted.stat().st_ctime
-                    )
-                except FileNotFoundError:
-                    node.attributes["status"] = None
-            elif success.is_file():
+                return
+            except FileNotFoundError:
+                pass
+            try:
+                node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
+                    success.stat().st_ctime
+                )
                 node.attributes["status"] = True
-                try:
-                    node.attributes["end_time_stamp"] = datetime.datetime.fromtimestamp(
-                        success.stat().st_ctime
-                    )
-                except FileNotFoundError:
-                    node.attributes["status"] = None
-            else:
-                node.attributes["status"] = None
+                return
+            except FileNotFoundError:
+                pass
+            node.attributes["status"] = None
 
     def _set_job_nodes(self, star_doc):
         self._job_nodes = copy.deepcopy(self._nodes)


### PR DESCRIPTION
Catch a `FileNotFoundError` when checking modification time of job SUCCESS file and just leave the job status as `None` if one is thrown (equivalent to saying the job is still running).