### PR TITLE
Check that all imported files have been preprocessed before allowing an exit

### DIFF
--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -172,6 +172,23 @@ class Project(RelionPipeline):
         Project.class2D.fget.cache_clear()
         Project.class3D.fget.cache_clear()
 
+    def get_imported(self):
+        try:
+            import_job_path = self.basepath / self.origin
+            gemmi_readable_path = os.fspath(import_job_path / "movies.star")
+            star_doc = cif.read_file(gemmi_readable_path)
+            for index, block in enumerate(star_doc):
+                if list(block.find_loop("_rlnMicrographMovieName")):
+                    block_index = index
+                    break
+            data_block = star_doc[block_index]
+            values = list(data_block.find_loop("_rlnMicrographMovieName"))
+            if not values:
+                print("Warning - no values found for _rlnMicrographMovieName")
+            return values
+        except (FileNotFoundError, RuntimeError):
+            return []
+
 
 class RelionResults:
     def __init__(self):

--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -257,20 +257,3 @@ class PipelineLock:
         if self.obtained:
             self.lockdir.rmdir()
         self.obtained = False
-
-
-def get_imported(import_job_path):
-    try:
-        gemmi_readable_path = os.fspath(import_job_path / "movies.star")
-        star_doc = cif.read_file(gemmi_readable_path)
-        for index, block in enumerate(star_doc):
-            if list(block.find_loop("_rlnMicrographMovieName")):
-                block_index = index
-                break
-        data_block = star_doc[block_index]
-        values = list(data_block.find_loop("_rlnMicrographMovieName"))
-        if not values:
-            print("Warning - no values found for _rlnMicrographMovieName")
-        return values
-    except (FileNotFoundError, RuntimeError):
-        return []

--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -5,6 +5,7 @@ https://github.com/DiamondLightSource/python-relion
 
 import functools
 import pathlib
+from gemmi import cif
 from relion._parser.ctffind import CTFFind
 from relion._parser.motioncorrection import MotionCorr
 from relion._parser.class2D import Class2D
@@ -12,6 +13,7 @@ from relion._parser.class3D import Class3D
 from relion._parser.relion_pipeline import RelionPipeline
 import time
 import copy
+import os
 
 __all__ = []
 __author__ = "Diamond Light Source - Scientific Software"
@@ -238,3 +240,20 @@ class PipelineLock:
         if self.obtained:
             self.lockdir.rmdir()
         self.obtained = False
+
+
+def get_imported(import_job_path):
+    try:
+        gemmi_readable_path = os.fspath(import_job_path / "movies.star")
+        star_doc = cif.read_file(gemmi_readable_path)
+        for index, block in enumerate(star_doc):
+            if list(block.find_loop("_rlnMicrographMovieName")):
+                block_index = index
+                break
+        data_block = star_doc[block_index]
+        values = list(data_block.find_loop("_rlnMicrographMovieName"))
+        if not values:
+            print("Warning - no values found for _rlnMicrographMovieName")
+        return values
+    except (FileNotFoundError, RuntimeError):
+        return []

--- a/src/relion/_parser/jobtype.py
+++ b/src/relion/_parser/jobtype.py
@@ -65,7 +65,8 @@ class JobType(collections.abc.Mapping):
             print("Warning - no values found for", loop_name)
         return values_list
 
-    def _find_table_from_column_name(self, cname, star_doc):
+    @staticmethod
+    def _find_table_from_column_name(cname, star_doc):
         for block_index, block in enumerate(star_doc):
             if list(block.find_loop(cname)):
                 return block_index

--- a/src/relion/_parser/processgraph.py
+++ b/src/relion/_parser/processgraph.py
@@ -34,6 +34,12 @@ class ProcessGraph(collections.abc.Sequence):
             raise ValueError("Index of ProcessGraph must be an integer")
         return self._node_list[index]
 
+    def get_by_name(self, name):
+        for i, j in enumerate(self):
+            if str(j.name) == name:
+                return self._node_list[i]
+        return None
+
     def extend(self, other):
         if not isinstance(other, ProcessGraph):
             raise ValueError("Can only extend a ProcessGraph with another ProcessGraph")

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -175,7 +175,8 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                         or job.attributes["job_count"] < 1
                     ):
                         break
-                    if mc_job_time_all_processed:
+                    # don't need to check if Import job has run recently for this bit
+                    if mc_job_time_all_processed and "Import" not in job.name:
                         if (
                             datetime.datetime.timestamp(job_start_time)
                             < mc_job_time_all_processed

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -154,9 +154,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
             # if they have then get the time stamp of the motion correction job
             # so that it can be checked all preprocessing jobs have run after it
             # only do this if the number of imported files has changed
-            new_imported_files = relion.get_imported(
-                relion_prj.basepath / relion_prj.origin
-            )
+            new_imported_files = relion_prj.get_imported()
             if new_imported_files != imported_files or not mc_job_time_all_processed:
                 imported_files = new_imported_files
                 mc_job_time_all_processed = self.check_processing_of_imports(

--- a/tests/parser/test_processgraph.py
+++ b/tests/parser/test_processgraph.py
@@ -207,3 +207,7 @@ def test_process_graph_show_all_nodes(mock_Digraph, graph):
 def test_process_graph_wipe(graph):
     graph.wipe()
     assert len(graph) == 0
+
+
+def test_get_by_name(graph):
+    assert graph.get_by_name("Project/MotionCorr/job002") == graph[1]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -56,9 +56,7 @@ def test_results_collection_does_not_crash_for_an_empty_project():
     assert results._results == []
 
 
-def test_get_imported_files_from_job_directory(dials_data):
-    imported = relion.get_imported(
-        dials_data("relion_tutorial_data", pathlib=True) / "Import" / "job001"
-    )
+def test_get_imported_files_from_job_directory(proj):
+    imported = proj.get_imported()
     assert len(imported) == 24
     assert imported[0] == "Movies/20170629_00021_frameImage.tiff"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -54,3 +54,11 @@ def test_results_collection_does_not_crash_for_an_empty_project():
     proj = relion.Project("./")
     results = proj.results
     assert results._results == []
+
+
+def test_get_imported_files_from_job_directory(dials_data):
+    imported = relion.get_imported(
+        dials_data("relion_tutorial_data", pathlib=True) / "Import" / "job001"
+    )
+    assert len(imported) == 24
+    assert imported[0] == "Movies/20170629_00021_frameImage.tiff"


### PR DESCRIPTION
Check that all the files in `Import/job001/movies.star` have been through a MotionCorr job by checking the file names against the cached MotionCorr micrograph names (after removing the file extension as it is `tiff` for the Import files and `mrc` for the MotionCorr results). If this check passes then it is only checked again if the list of imported files changes. 

Preprocessing jobs are checked to ensure that they have all been run more recently than the last MotionCorr job that finished the complete set of imported files.