### PR TITLE
Fixes for race conditions that have shown up during testing

### DIFF
--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -184,7 +184,7 @@ class Project(RelionPipeline):
             data_block = star_doc[block_index]
             values = list(data_block.find_loop("_rlnMicrographMovieName"))
             if not values:
-                print("Warning - no values found for _rlnMicrographMovieName")
+                return []
             return values
         except (FileNotFoundError, RuntimeError):
             return []

--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -51,10 +51,15 @@ class Class2D(JobType):
 
         dfile, mfile = self._final_data_and_model(jobdir)
 
-        sdfile = self._read_star_file(jobdir, dfile)
-        smfile = self._read_star_file(jobdir, mfile)
+        try:
+            sdfile = self._read_star_file(jobdir, dfile)
+            smfile = self._read_star_file(jobdir, mfile)
+        except RuntimeError:
+            return []
 
         info_table = self._find_table_from_column_name("_rlnClassDistribution", smfile)
+        if info_table is None:
+            return []
 
         class_distribution = self.parse_star_file(
             "_rlnClassDistribution", smfile, info_table

--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -49,7 +49,13 @@ class Class2D(JobType):
 
     def _load_job_directory(self, jobdir):
 
-        dfile, mfile = self._final_data_and_model(jobdir)
+        try:
+            dfile, mfile = self._final_data_and_model(jobdir)
+        except ValueError as e:
+            print(
+                f"The exception {e} was caught while trying to get data and model files. Returning an empty list"
+            )
+            return []
 
         try:
             sdfile = self._read_star_file(jobdir, dfile)

--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -98,7 +98,7 @@ class Class2D(JobType):
         int_particle_sum = [(int(name), value) for name, value in particle_sum.items()]
         # something probably went wrong with file reading if this is the case
         # return empty list and hope to recover later
-        if len(int_particle_sum) == 0:
+        if not int_particle_sum:
             return []
         checked_particle_list = self._class_checker(
             sorted(int_particle_sum), len(reference_image)

--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -2,6 +2,9 @@ from collections import namedtuple
 from collections import Counter
 from operator import attrgetter
 from relion._parser.jobtype import JobType
+import logging
+
+logger = logging.getLogger("relion._parser.class2D")
 
 Class2DParticleClass = namedtuple(
     "Class2DParticleClass",
@@ -52,8 +55,9 @@ class Class2D(JobType):
         try:
             dfile, mfile = self._final_data_and_model(jobdir)
         except ValueError as e:
-            print(
-                f"The exception {e} was caught while trying to get data and model files. Returning an empty list"
+            logger.debug(
+                f"The exception {e} was caught while trying to get data and model files. Returning an empty list",
+                exc_info=True,
             )
             return []
 
@@ -61,10 +65,15 @@ class Class2D(JobType):
             sdfile = self._read_star_file(jobdir, dfile)
             smfile = self._read_star_file(jobdir, mfile)
         except RuntimeError:
+            logger.debug(
+                "gemmi could not open file while trying to get data and model files. Returning an empty list",
+                exc_info=True,
+            )
             return []
 
         info_table = self._find_table_from_column_name("_rlnClassDistribution", smfile)
         if info_table is None:
+            logger.debug(f"_rlnClassDistribution not found in file {mfile}")
             return []
 
         class_distribution = self.parse_star_file(

--- a/src/relion/_parser/class2D.py
+++ b/src/relion/_parser/class2D.py
@@ -76,6 +76,10 @@ class Class2D(JobType):
         class_numbers = self.parse_star_file("_rlnClassNumber", sdfile, info_table)
         particle_sum = self._sum_all_particles(class_numbers)
         int_particle_sum = [(int(name), value) for name, value in particle_sum.items()]
+        # something probably went wrong with file reading if this is the case
+        # return empty list and hope to recover later
+        if len(int_particle_sum) == 0:
+            return []
         checked_particle_list = self._class_checker(
             sorted(int_particle_sum), len(reference_image)
         )

--- a/src/relion/_parser/class3D.py
+++ b/src/relion/_parser/class3D.py
@@ -56,10 +56,15 @@ class Class3D(JobType):
 
         dfile, mfile = self._final_data_and_model(jobdir)
 
-        sdfile = self._read_star_file(jobdir, dfile)
-        smfile = self._read_star_file(jobdir, mfile)
+        try:
+            sdfile = self._read_star_file(jobdir, dfile)
+            smfile = self._read_star_file(jobdir, mfile)
+        except RuntimeError:
+            return []
 
         info_table = self._find_table_from_column_name("_rlnClassDistribution", smfile)
+        if info_table is None:
+            return []
 
         class_distribution = self.parse_star_file(
             "_rlnClassDistribution", smfile, info_table

--- a/src/relion/_parser/class3D.py
+++ b/src/relion/_parser/class3D.py
@@ -1,7 +1,9 @@
 from collections import namedtuple
 from collections import Counter
 from relion._parser.jobtype import JobType
+import logging
 
+logger = logging.getLogger("relion._parser.class3D")
 
 Class3DParticleClass = namedtuple(
     "Class3DParticleClass",
@@ -57,8 +59,9 @@ class Class3D(JobType):
         try:
             dfile, mfile = self._final_data_and_model(jobdir)
         except ValueError as e:
-            print(
-                f"The exception {e} was caught while trying to get data and model files. Returning an empty list"
+            logger.debug(
+                f"The exception {e} was caught while trying to get data and model files. Returning an empty list",
+                exc_info=True,
             )
             return []
 
@@ -66,10 +69,15 @@ class Class3D(JobType):
             sdfile = self._read_star_file(jobdir, dfile)
             smfile = self._read_star_file(jobdir, mfile)
         except RuntimeError:
+            logger.debug(
+                "gemmi could not open file while trying to get data and model files. Returning an empty list",
+                exc_info=True,
+            )
             return []
 
         info_table = self._find_table_from_column_name("_rlnClassDistribution", smfile)
         if info_table is None:
+            logger.debug(f"_rlnClassDistribution not found in file {mfile}")
             return []
 
         class_distribution = self.parse_star_file(

--- a/src/relion/_parser/class3D.py
+++ b/src/relion/_parser/class3D.py
@@ -54,7 +54,13 @@ class Class3D(JobType):
 
     def _load_job_directory(self, jobdir):
 
-        dfile, mfile = self._final_data_and_model(jobdir)
+        try:
+            dfile, mfile = self._final_data_and_model(jobdir)
+        except ValueError as e:
+            print(
+                f"The exception {e} was caught while trying to get data and model files. Returning an empty list"
+            )
+            return []
 
         try:
             sdfile = self._read_star_file(jobdir, dfile)

--- a/src/relion/_parser/class3D.py
+++ b/src/relion/_parser/class3D.py
@@ -81,6 +81,10 @@ class Class3D(JobType):
         class_numbers = self.parse_star_file("_rlnClassNumber", sdfile, info_table)
         particle_sum = self._sum_all_particles(class_numbers)
         int_particle_sum = [(int(name), value) for name, value in particle_sum.items()]
+        # something probably went wrong with file reading if this is the case
+        # return empty list and hope to recover later
+        if len(int_particle_sum) == 0:
+            return []
         checked_particle_list = self._class_checker(
             sorted(int_particle_sum), len(reference_image)
         )

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -52,9 +52,14 @@ class CTFFind(JobType):
         return jobs
 
     def _load_job_directory(self, jobdir):
-        file = self._read_star_file(jobdir, "micrographs_ctf.star")
+        try:
+            file = self._read_star_file(jobdir, "micrographs_ctf.star")
+        except RuntimeError:
+            return []
 
         info_table = self._find_table_from_column_name("_rlnCtfAstigmatism", file)
+        if info_table is None:
+            return []
 
         astigmatism = self.parse_star_file("_rlnCtfAstigmatism", file, info_table)
         defocus_u = self.parse_star_file("_rlnDefocusU", file, info_table)

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -30,9 +30,14 @@ class MotionCorr(JobType):
         return f"<MotionCorr parser at {self._basepath}>"
 
     def _load_job_directory(self, jobdir):
-        file = self._read_star_file(jobdir, "corrected_micrographs.star")
+        try:
+            file = self._read_star_file(jobdir, "corrected_micrographs.star")
+        except RuntimeError:
+            return []
 
         info_table = self._find_table_from_column_name("_rlnAccumMotionTotal", file)
+        if info_table is None:
+            return []
 
         accum_motion_total = self.parse_star_file(
             "_rlnAccumMotionTotal", file, info_table

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -242,8 +242,9 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                 )
             return
         except (KeyError, AttributeError, RuntimeError, FileNotFoundError) as e:
-            logger.warning(
-                f"Exception encountered while checking whether imported files have been processed: {e}"
+            logger.debug(
+                f"Exception encountered while checking whether imported files have been processed: {e}",
+                exc_info=True,
             )
             return
 

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -145,12 +145,10 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
             # if Relion has been running too long stop loop of preprocessing jobs
             try:
                 most_recent_movie = max(
-                    [
-                        p.stat().st_mtime
-                        for p in pathlib.Path(self.params["image_directory"]).glob(
-                            "**/*"
-                        )
-                    ]
+                    p.stat().st_mtime
+                    for p in pathlib.Path(self.params["image_directory"]).glob(
+                        "**/*"
+                    )
                 )
             # if a file vanishes for some reason make sure that there is no crash and no exit
             except FileNotFoundError:

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -241,7 +241,10 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                     ).attributes["start_time_stamp"]
                 )
             return
-        except (KeyError, AttributeError, RuntimeError, FileNotFoundError):
+        except (KeyError, AttributeError, RuntimeError, FileNotFoundError) as e:
+            logger.warning(
+                f"Exception encountered while checking whether imported files have been processed: {e}"
+            )
             return
 
     def start_relion(self):

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -111,7 +111,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         ) and False not in [n.attributes["status"] for n in relion_prj]:
             time.sleep(1)
 
-            logger.info("Looking for results")
+            # logger.info("Looking for results")
 
             ispyb_command_list = []
 
@@ -143,12 +143,18 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                 logger.info("Sent %d commands to ISPyB", len(ispyb_command_list))
 
             # if Relion has been running too long stop loop of preprocessing jobs
-            most_recent_movie = max(
-                [
-                    p.stat().st_mtime
-                    for p in pathlib.Path(self.params["image_directory"]).glob("**/*")
-                ]
-            )
+            try:
+                most_recent_movie = max(
+                    [
+                        p.stat().st_mtime
+                        for p in pathlib.Path(self.params["image_directory"]).glob(
+                            "**/*"
+                        )
+                    ]
+                )
+            # if a file vanishes for some reason make sure that there is no crash and no exit
+            except FileNotFoundError:
+                most_recent_movie = time.time()
 
             # check if all imported files have been motion corrected
             # if they have then get the time stamp of the motion correction job
@@ -235,7 +241,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                     ).attributes["start_time_stamp"]
                 )
             return
-        except (KeyError, RuntimeError, FileNotFoundError):
+        except (KeyError, AttributeError, RuntimeError, FileNotFoundError):
             return
 
     def start_relion(self):


### PR DESCRIPTION
These fixes should cover:

* Files disappearing in the `Movies` directory
* The case where `len(int_particle_sum) == 0` crashes 2D and 3D `_class_checker`
* Inability of `gemmi` to read data files, probably due to them being overwritten by Relion at the time

The changes mean that blank data entries are returned when before there would be a crash.