### PR TITLE
Use DLSImages service to convert from mrc to jpeg for CTF diagnostic image and motion corrected micrograph

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 gemmi==0.4.6
-opencv-python>=4.5
-mrcfile>=1.3
+mrcfile==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 gemmi==0.4.6
 mrcfile==1.3
+pillow==8.0
+numpy==1.21; python_version >= '3.7'
+numpy==1.19; python_version < '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 gemmi==0.4.6
+opencv-python>=4.5
+mrcfile>=1.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,5 @@ gemmi==0.4.6
 graphviz==0.16
 pytest==6.2.4
 pytest-cov==2.12.0
+opencv-python>=4.5
+mrcfile>=1.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,4 @@ graphviz==0.16
 pytest==6.2.4
 pytest-cov==2.12.0
 mrcfile==1.3
+numpy==1.20

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,5 +4,4 @@ gemmi==0.4.6
 graphviz==0.16
 pytest==6.2.4
 pytest-cov==2.12.0
-opencv-python>=4.5
-mrcfile>=1.3
+mrcfile==1.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,4 +5,6 @@ graphviz==0.16
 pytest==6.2.4
 pytest-cov==2.12.0
 mrcfile==1.3
-numpy==1.20
+pillow==8.0
+numpy==1.21; python_version >= '3.7'
+numpy==1.19; python_version < '3.7'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,6 @@ graphviz==0.16
 pytest==6.2.4
 pytest-cov==2.12.0
 mrcfile==1.3
-workflows==2.9
 pillow==8.0
 numpy==1.21; python_version >= '3.7'
 numpy==1.19; python_version < '3.7'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,7 @@ graphviz==0.16
 pytest==6.2.4
 pytest-cov==2.12.0
 mrcfile==1.3
+workflows==2.9
 pillow==8.0
 numpy==1.21; python_version >= '3.7'
 numpy==1.19; python_version < '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ project-urls =
 include_package_data = True
 install_requires =
     gemmi
+    mrcfile
+    pillow
+    numpy
 packages = find:
 package_dir =
     =src
@@ -48,7 +51,7 @@ workflows.services =
     RelionStopService = relion.zocalo.service:RelionStopService
 zocalo.wrappers =
     relion = relion.zocalo.wrapper:RelionWrapper
-images.zocalo.service.plugins = 
+zocalo.services.images.plugins = 
     mrc_to_jpeg = relion.zocalo.images_service_plugin:mrc_to_jpeg
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,8 @@ workflows.services =
     RelionStopService = relion.zocalo.service:RelionStopService
 zocalo.wrappers =
     relion = relion.zocalo.wrapper:RelionWrapper
+images.zocalo.service.plugins = 
+    mrc_to_jpeg = relion.zocalo.images_service_plugin:mrc_to_jpeg
 
 [options.packages.find]
 where = src

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from relion._parser.jobtype import JobType
+import pathlib
 import logging
 
 logger = logging.getLogger("relion._parser.ctffind")
@@ -88,7 +89,7 @@ class CTFFind(JobType):
         for j in range(len(micrograph_name)):
             # plot_path = self._make_ctf_jpg(ctf_img_path[j].split(":")[0])
             plot_path = (
-                str(self._basepath.parent / ctf_img_path[j])
+                str(pathlib.PurePosixPath(self._basepath.parent) / ctf_img_path[j])
                 .split(":")[0]
                 .replace(".ctf", ".jpeg")
             )

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 from relion._parser.jobtype import JobType
-import pathlib
 import logging
 
 logger = logging.getLogger("relion._parser.ctffind")
@@ -87,9 +86,8 @@ class CTFFind(JobType):
 
         micrograph_list = []
         for j in range(len(micrograph_name)):
-            # plot_path = self._make_ctf_jpg(ctf_img_path[j].split(":")[0])
             plot_path = (
-                str(pathlib.PurePosixPath(self._basepath.parent) / ctf_img_path[j])
+                (str(self._basepath.parent) + "/" + ctf_img_path[j])
                 .split(":")[0]
                 .replace(".ctf", ".jpeg")
             )

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -86,8 +86,10 @@ class CTFFind(JobType):
         micrograph_list = []
         for j in range(len(micrograph_name)):
             # plot_path = self._make_ctf_jpg(ctf_img_path[j].split(":")[0])
-            plot_path = self._basepath.parent / ctf_img_path[j].split(":")[0].replace(
-                ".ctf", ".jpeg"
+            plot_path = (
+                str(self._basepath.parent / ctf_img_path[j])
+                .split(":")[0]
+                .replace(".ctf", ".jpeg")
             )
             micrograph_list.append(
                 CTFMicrograph(

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -87,7 +87,7 @@ class CTFFind(JobType):
         micrograph_list = []
         for j in range(len(micrograph_name)):
             plot_path = (
-                (str(self._basepath.parent) + "/" + ctf_img_path[j])
+                str(self._basepath.parent / ctf_img_path[j])
                 .split(":")[0]
                 .replace(".ctf", ".jpeg")
             )

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from relion._parser.jobtype import JobType
 import logging
 
-logger = logging.getLogger("relion._parser.class3D")
+logger = logging.getLogger("relion._parser.ctffind")
 
 CTFMicrograph = namedtuple(
     "CTFMicrograph",

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -1,5 +1,3 @@
-import cv2
-import mrcfile
 from collections import namedtuple
 from relion._parser.jobtype import JobType
 import logging
@@ -37,6 +35,9 @@ CTFMicrograph.fig_of_merit.__doc__ = (
     "Figure of merit/CC/correlation value. Confidence of the defocus estimation."
 )
 CTFMicrograph.amp_contrast.__doc__ = "Amplitude contrast."
+CTFMicrograph.diagnostic_plot_path.__doc__ = (
+    "Path to the CTF diagnostic (fit/data comparison) plot (jpeg)."
+)
 
 
 class CTFFind(JobType):
@@ -105,24 +106,6 @@ class CTFFind(JobType):
                 )
             )
         return micrograph_list
-
-    def _make_ctf_jpg(self, proj_path_to_mrc):
-        jpg_path = proj_path_to_mrc.split(".")[0] + ".jpg"
-        try:
-            with mrcfile.open(self._basepath.parent / proj_path_to_mrc) as mrc:
-                data = mrc.data
-        except FileNotFoundError:
-            logger.debug(
-                f"File {self._basepath.parent / proj_path_to_mrc} not found. No CTF jpg produced."
-            )
-            return jpg_path
-        data = data - data.min()
-        data *= 255 / data.max()
-        int_data = data.astype(int)
-        out_file = self._basepath.parent / jpg_path
-        print("writing:", out_file)
-        cv2.imwrite(str(out_file), int_data[0])
-        return jpg_path
 
     @staticmethod
     def for_cache(ctfmicrograph):

--- a/src/relion/_parser/ctffind.py
+++ b/src/relion/_parser/ctffind.py
@@ -85,7 +85,10 @@ class CTFFind(JobType):
 
         micrograph_list = []
         for j in range(len(micrograph_name)):
-            plot_path = self._make_ctf_jpg(ctf_img_path[j].split(":")[0])
+            # plot_path = self._make_ctf_jpg(ctf_img_path[j].split(":")[0])
+            plot_path = self._basepath.parent / ctf_img_path[j].split(":")[0].replace(
+                ".ctf", ".jpeg"
+            )
             micrograph_list.append(
                 CTFMicrograph(
                     micrograph_name[j],

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -8,7 +8,8 @@ MCMicrograph = namedtuple(
     "MCMicrograph",
     [
         "micrograph_name",
-        "micrograph_snapshot_full_path" "micrograph_number",
+        "micrograph_snapshot_full_path",
+        "micrograph_number",
         "total_motion",
         "early_motion",
         "late_motion",

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -19,6 +19,9 @@ MCMicrograph = namedtuple(
 
 MCMicrograph.__doc__ = "Motion Correction stage."
 MCMicrograph.micrograph_name.__doc__ = "Micrograph name. Useful for reference."
+MCMicrograph.micrograph_snapshot_full_path.__doc__ = (
+    "Path to jpeg of the motion corrected micrograph."
+)
 MCMicrograph.micrograph_number.__doc__ = "Micrograph number: sequential in time."
 MCMicrograph.total_motion.__doc__ = (
     "Total motion. The amount the sample moved during exposure. Units angstrom (A)."

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -8,7 +8,7 @@ MCMicrograph = namedtuple(
     "MCMicrograph",
     [
         "micrograph_name",
-        "micrograph_number",
+        "micrograph_snapshot_full_path" "micrograph_number",
         "total_motion",
         "early_motion",
         "late_motion",
@@ -94,6 +94,7 @@ class MotionCorr(JobType):
             micrograph_list.append(
                 MCMicrograph(
                     micrograph_name[j],
+                    str(self._basepath / micrograph_name[j]).replace(".mrc", ".jpeg"),
                     j + 1,
                     accum_motion_total[j],
                     accum_motion_early[j],

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -98,7 +98,9 @@ class MotionCorr(JobType):
             micrograph_list.append(
                 MCMicrograph(
                     micrograph_name[j],
-                    str(self._basepath / micrograph_name[j]).replace(".mrc", ".jpeg"),
+                    str(self._basepath.parent / micrograph_name[j]).replace(
+                        ".mrc", ".jpeg"
+                    ),
                     j + 1,
                     accum_motion_total[j],
                     accum_motion_early[j],

--- a/src/relion/zocalo/images_service_plugin.py
+++ b/src/relion/zocalo/images_service_plugin.py
@@ -1,0 +1,54 @@
+import mrcfile
+import PIL.Image
+import pathlib
+import numpy as np
+import logging
+
+logger = logging.getLogger("relion.zocalo.images_service_plugin")
+
+
+def mrc_to_jpeg(params):
+    filename = params.rw.recipe_step.get("parameters", {}).get("file")
+    allframes = params.rw.recipe_step.get("parameters", {}).get("all_frames")
+    if isinstance(params.message, dict) and params.message.get("file"):
+        filename = params.message["file"]
+        allframes = params.message.get("all_frames")
+    else:
+        filename = None
+    if not filename or filename == "None":
+        logger.debug("Skipping mrc to jpeg conversion: filename not specified")
+        params.rw.transport.ack(params.header)
+        return
+    filepath = pathlib.Path(filename)
+    if not filepath.is_file():
+        logger.error(f"File {filepath} not found")
+        params.rw.transport.nack(params.header)
+        return
+    try:
+        with mrcfile.open(filepath) as mrc:
+            data = mrc.data
+    except ValueError:
+        logger.error(
+            "File {filepath} could not be opened. It may be corrupted or not in mrc format"
+        )
+        params.rw.transport.nack(params.header)
+        return
+    data = data - data.min()
+    data = data * 255 / data.max()
+    data = data.astype(np.uint8)
+    outfile = filepath.with_suffix(".jpeg")
+    if len(data.shape) == 2:
+        im = PIL.Image.fromarray(data, mode="L")
+        im.save(outfile)
+    elif len(data.shape) == 3:
+        if allframes:
+            for i, frame in enumerate(data):
+                im = PIL.Image.fromarray(frame, mode="L")
+                frame_outfile = str(outfile).replace(".jpeg", f"_{i+1}.jpeg")
+                im.save(frame_outfile)
+        else:
+            im = PIL.Image.fromarray(data[0], mode="L")
+            im.save(outfile)
+
+    logger.info(f"Converted mrc to jpeg {filename} -> {outfile}")
+    params.rw.transport.ack(params.header)

--- a/src/relion/zocalo/images_service_plugin.py
+++ b/src/relion/zocalo/images_service_plugin.py
@@ -7,22 +7,15 @@ import logging
 logger = logging.getLogger("relion.zocalo.images_service_plugin")
 
 
-def mrc_to_jpeg(params):
-    filename = params.rw.recipe_step.get("parameters", {}).get("file")
-    allframes = params.rw.recipe_step.get("parameters", {}).get("all_frames")
-    if isinstance(params.message, dict) and params.message.get("file"):
-        filename = params.message["file"]
-        allframes = params.message.get("all_frames")
-    else:
-        filename = None
+def mrc_to_jpeg(plugin_params):
+    filename = plugin_params.parameters("file")
+    allframes = plugin_params.parameters("all_frames")
     if not filename or filename == "None":
         logger.debug("Skipping mrc to jpeg conversion: filename not specified")
-        params.rw.transport.ack(params.header)
         return
     filepath = pathlib.Path(filename)
     if not filepath.is_file():
         logger.error(f"File {filepath} not found")
-        params.rw.transport.nack(params.header)
         return
     try:
         with mrcfile.open(filepath) as mrc:
@@ -31,12 +24,12 @@ def mrc_to_jpeg(params):
         logger.error(
             "File {filepath} could not be opened. It may be corrupted or not in mrc format"
         )
-        params.rw.transport.nack(params.header)
         return
     data = data - data.min()
     data = data * 255 / data.max()
     data = data.astype(np.uint8)
     outfile = filepath.with_suffix(".jpeg")
+    outfiles = []
     if len(data.shape) == 2:
         im = PIL.Image.fromarray(data, mode="L")
         im.save(outfile)
@@ -46,9 +39,12 @@ def mrc_to_jpeg(params):
                 im = PIL.Image.fromarray(frame, mode="L")
                 frame_outfile = str(outfile).replace(".jpeg", f"_{i+1}.jpeg")
                 im.save(frame_outfile)
+                outfiles.append(frame_outfile)
         else:
             im = PIL.Image.fromarray(data[0], mode="L")
             im.save(outfile)
 
     logger.info(f"Converted mrc to jpeg {filename} -> {outfile}")
-    params.rw.transport.ack(params.header)
+    if outfiles:
+        return outfiles
+    return outfile

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -341,18 +341,18 @@ def images_msgs(relion_stage_object, job_string: str):
 
 @images_msgs.register(relion.MotionCorr)
 def _(stage_object: relion.MotionCorr, job_string: str):
-    imgs = []
-    for micrograph in stage_object[job_string]:
-        imgs.append(micrograph.micrograph_snapshot_full_path.replace(".jpeg", ".mrc"))
-    return imgs
+    return [
+        micrograph.micrograph_snapshot_full_path.replace(".jpeg", ".mrc")
+        for micrograph in stage_object[job_string]
+    ]
 
 
 @images_msgs.register(relion.CTFFind)
 def _(stage_object: relion.CTFFind, job_string: str):
-    imgs = []
-    for ctf_micrograph in stage_object[job_string]:
-        imgs.append(ctf_micrograph.diagnostic_plot_path.replace(".jpeg", ".ctf"))
-    return imgs
+    return [
+        ctf_micrograph.diagnostic_plot_path.replace(".jpeg", ".ctf")
+        for ctf_micrograph in stage_object[job_string]
+    ]
 
 
 @functools.singledispatch

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -358,6 +358,7 @@ def _(stage_object: relion.CTFFind, job_string: str, relion_options: RelionItOpt
                 / 2,
                 "cc_value": ctf_micrograph.fig_of_merit,
                 "amplitude_contrast": ctf_micrograph.amp_contrast,
+                "fft_theoretical_full_path": ctf_micrograph.diagnostic_plot_path,
                 "box_size_x": relion_options.ctffind_boxsize,
                 "box_size_y": relion_options.ctffind_boxsize,
                 "min_resolution": relion_options.ctffind_minres,

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -341,6 +341,14 @@ def images_msgs(relion_stage_object, job_string: str):
     return []
 
 
+@images_msgs.register(relion.MotionCorr)
+def _(stage_object: relion.MotionCorr, job_string: str):
+    imgs = []
+    for micrograph in stage_object[job_string]:
+        imgs.append(micrograph.micrograph_snapshot_full_path.replace(".jpeg", ".ctf"))
+    return imgs
+
+
 @images_msgs.register(relion.CTFFind)
 def _(stage_object: relion.CTFFind, job_string: str):
     imgs = []

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -148,9 +148,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                 logger.info("Sent %d commands to ISPyB", len(ispyb_command_list))
 
             for img in images_command_list:
-                self.recwrap.send_to(
-                    "images", {"image_command": "do_mrc_to_jpeg", "file": img}
-                )
+                self.recwrap.send_to("images", {"file": img})
 
             # if Relion has been running too long stop loop of preprocessing jobs
             try:
@@ -345,7 +343,7 @@ def images_msgs(relion_stage_object, job_string: str):
 def _(stage_object: relion.MotionCorr, job_string: str):
     imgs = []
     for micrograph in stage_object[job_string]:
-        imgs.append(micrograph.micrograph_snapshot_full_path.replace(".jpeg", ".ctf"))
+        imgs.append(micrograph.micrograph_snapshot_full_path.replace(".jpeg", ".mrc"))
     return imgs
 
 

--- a/tests/parser/test_ctffind.py
+++ b/tests/parser/test_ctffind.py
@@ -1,6 +1,7 @@
 import pytest
 import sys
 import relion
+import pathlib
 
 
 @pytest.fixture
@@ -79,3 +80,14 @@ def test_invalid_job_references_raise_KeyErrors(ctffind):
 
 def test_astigmatism(ctffind):
     assert ctffind["job003"][0].astigmatism == "288.135742"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def test_diagnosis_plot_path(proj, ctffind):
+    assert ctffind["job003"][0].diagnostic_plot_path == str(
+        pathlib.PurePosixPath(proj.basepath)
+        / "CtfFind"
+        / "job003"
+        / "Movies"
+        / "20170629_00021_frameImage_PS.jpeg"
+    )

--- a/tests/parser/test_ctffind.py
+++ b/tests/parser/test_ctffind.py
@@ -1,7 +1,6 @@
 import pytest
 import sys
 import relion
-import pathlib
 
 
 @pytest.fixture
@@ -85,7 +84,7 @@ def test_astigmatism(ctffind):
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_diagnosis_plot_path(proj, ctffind):
     assert ctffind["job003"][0].diagnostic_plot_path == str(
-        pathlib.PurePosixPath(proj.basepath)
+        proj.basepath
         / "CtfFind"
         / "job003"
         / "Movies"

--- a/tests/zocalo/test_images_service_plugin.py
+++ b/tests/zocalo/test_images_service_plugin.py
@@ -37,7 +37,7 @@ def test_mrc_to_jpeg_nack_when_file_not_found(proj):
 
     rw = RW_mock()
     rw.transport = ct
-    rw.recipe_step = {"parameters": {"images_command": "do_mrc_to_jpeg"}}
+    rw.recipe_step = {"parameters": {"images_command": "mrc_to_jpeg"}}
     rw.environment = {"has_recipe_wrapper": False}
     rw.set_default_channel = rw.dummy
     rw.send = rw.dummy
@@ -75,7 +75,7 @@ def test_mrc_to_jpeg_ack_when_file_exists(tmp_path):
 
     rw = RW_mock()
     rw.transport = ct
-    rw.recipe_step = {"parameters": {"images_command": "do_mrc_to_jpeg"}}
+    rw.recipe_step = {"parameters": {"images_command": "mrc_to_jpeg"}}
     rw.environment = {"has_recipe_wrapper": False}
     rw.set_default_channel = rw.dummy
     rw.send = rw.dummy

--- a/tests/zocalo/test_images_service_plugin.py
+++ b/tests/zocalo/test_images_service_plugin.py
@@ -1,13 +1,11 @@
 import pytest
 import relion
-import pathlib
 import mrcfile
 import sys
+import os
 import numpy as np
-from unittest import mock
 from relion.zocalo.images_service_plugin import mrc_to_jpeg
-from typing import NamedTuple
-from workflows.transport.common_transport import CommonTransport
+from typing import NamedTuple, Callable, Any
 
 
 @pytest.fixture
@@ -15,84 +13,44 @@ def proj(dials_data):
     return relion.Project(dials_data("relion_tutorial_data"))
 
 
+def plugin_params(jpeg_path):
+    def params(key):
+        p = {
+            "parameters": {"images_command": "mrc_to_jpeg"},
+            "file": jpeg_path.with_suffix(".mrc"),
+        }
+        return p.get(key)
+
+    class FunctionParameter(NamedTuple):
+        rw: Any
+        parameters: Callable
+        message: dict
+
+    return FunctionParameter(None, params, {})
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_mrc_to_jpeg_nack_when_file_not_found(proj):
     ctf_data = proj.ctffind["job003"]
-    jpeg_path = str(
-        pathlib.PurePosixPath(proj.basepath)
+    jpeg_path = (
+        proj.basepath
         / "CtfFind"
         / "job003"
         / "Movies"
         / "20170629_00021_frameImage_PS.jpeg"
     )
-    assert ctf_data[0].diagnostic_plot_path == jpeg_path
+    assert ctf_data[0].diagnostic_plot_path == os.fspath(jpeg_path)
 
-    class RW_mock:
-        def dummy(self, *args, **kwargs):
-            pass
-
-    ct = CommonTransport()
-    ct.ack = mock.Mock()
-    ct.nack = mock.Mock()
-
-    rw = RW_mock()
-    rw.transport = ct
-    rw.recipe_step = {"parameters": {"images_command": "mrc_to_jpeg"}}
-    rw.environment = {"has_recipe_wrapper": False}
-    rw.set_default_channel = rw.dummy
-    rw.send = rw.dummy
-
-    msg = {"file": jpeg_path.replace(".jpeg", ".ctf")}
-    header = {}
-
-    class FunctionParameter(NamedTuple):
-        rw: RW_mock
-        message: dict
-        header: dict
-
-    params = FunctionParameter(rw, msg, header)
-
-    mrc_to_jpeg(params)
-
-    ct.nack.assert_called_once()
-    ct.ack.assert_not_called()
+    assert mrc_to_jpeg(plugin_params(jpeg_path)) is None
 
 
 def test_mrc_to_jpeg_ack_when_file_exists(tmp_path):
-    jpeg_path = str(tmp_path / "convert_test.jpeg")
+    jpeg_path = tmp_path / "convert_test.jpeg"
 
     test_data = np.arange(9, dtype=np.int8).reshape(3, 3)
-    with mrcfile.new(jpeg_path.replace(".jpeg", ".mrc")) as mrc:
+    with mrcfile.new(jpeg_path.with_suffix(".mrc")) as mrc:
         mrc.set_data(test_data)
 
-    class RW_mock:
-        def dummy(self, *args, **kwargs):
-            pass
+    assert mrc_to_jpeg(plugin_params(jpeg_path)) == jpeg_path
 
-    ct = CommonTransport()
-    ct.ack = mock.Mock()
-    ct.nack = mock.Mock()
-
-    rw = RW_mock()
-    rw.transport = ct
-    rw.recipe_step = {"parameters": {"images_command": "mrc_to_jpeg"}}
-    rw.environment = {"has_recipe_wrapper": False}
-    rw.set_default_channel = rw.dummy
-    rw.send = rw.dummy
-
-    msg = {"file": jpeg_path.replace(".jpeg", ".mrc")}
-    header = {}
-
-    class FunctionParameter(NamedTuple):
-        rw: RW_mock
-        message: dict
-        header: dict
-
-    params = FunctionParameter(rw, msg, header)
-
-    mrc_to_jpeg(params)
-
-    ct.nack.assert_not_called()
-    ct.ack.assert_called_once()
-
-    assert pathlib.Path(jpeg_path).is_file()
+    assert jpeg_path.is_file()

--- a/tests/zocalo/test_images_service_plugin.py
+++ b/tests/zocalo/test_images_service_plugin.py
@@ -17,7 +17,7 @@ def proj(dials_data):
 def test_mrc_to_jpeg_nack_when_file_not_found(proj):
     ctf_data = proj.ctffind["job003"]
     jpeg_path = str(
-        proj.basepath
+        pathlib.PurePosixPath(proj.basepath)
         / "CtfFind"
         / "job003"
         / "Movies"

--- a/tests/zocalo/test_images_service_plugin.py
+++ b/tests/zocalo/test_images_service_plugin.py
@@ -2,6 +2,7 @@ import pytest
 import relion
 import pathlib
 import mrcfile
+import sys
 import numpy as np
 from unittest import mock
 from relion.zocalo.images_service_plugin import mrc_to_jpeg
@@ -14,6 +15,7 @@ def proj(dials_data):
     return relion.Project(dials_data("relion_tutorial_data"))
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_mrc_to_jpeg_nack_when_file_not_found(proj):
     ctf_data = proj.ctffind["job003"]
     jpeg_path = str(

--- a/tests/zocalo/test_images_service_plugin.py
+++ b/tests/zocalo/test_images_service_plugin.py
@@ -1,0 +1,96 @@
+import pytest
+import relion
+import pathlib
+import mrcfile
+import numpy as np
+from unittest import mock
+from relion.zocalo.images_service_plugin import mrc_to_jpeg
+from typing import NamedTuple
+from workflows.transport.common_transport import CommonTransport
+
+
+@pytest.fixture
+def proj(dials_data):
+    return relion.Project(dials_data("relion_tutorial_data"))
+
+
+def test_mrc_to_jpeg_nack_when_file_not_found(proj):
+    ctf_data = proj.ctffind["job003"]
+    jpeg_path = str(
+        proj.basepath
+        / "CtfFind"
+        / "job003"
+        / "Movies"
+        / "20170629_00021_frameImage_PS.jpeg"
+    )
+    assert ctf_data[0].diagnostic_plot_path == jpeg_path
+
+    class RW_mock:
+        def dummy(self, *args, **kwargs):
+            pass
+
+    ct = CommonTransport()
+    ct.ack = mock.Mock()
+    ct.nack = mock.Mock()
+
+    rw = RW_mock()
+    rw.transport = ct
+    rw.recipe_step = {"parameters": {"images_command": "do_mrc_to_jpeg"}}
+    rw.environment = {"has_recipe_wrapper": False}
+    rw.set_default_channel = rw.dummy
+    rw.send = rw.dummy
+
+    msg = {"file": jpeg_path.replace(".jpeg", ".ctf")}
+    header = {}
+
+    class FunctionParameter(NamedTuple):
+        rw: RW_mock
+        message: dict
+        header: dict
+
+    params = FunctionParameter(rw, msg, header)
+
+    mrc_to_jpeg(params)
+
+    ct.nack.assert_called_once()
+    ct.ack.assert_not_called()
+
+
+def test_mrc_to_jpeg_ack_when_file_exists(tmp_path):
+    jpeg_path = str(tmp_path / "convert_test.jpeg")
+
+    test_data = np.arange(9, dtype=np.int8).reshape(3, 3)
+    with mrcfile.new(jpeg_path.replace(".jpeg", ".mrc")) as mrc:
+        mrc.set_data(test_data)
+
+    class RW_mock:
+        def dummy(self, *args, **kwargs):
+            pass
+
+    ct = CommonTransport()
+    ct.ack = mock.Mock()
+    ct.nack = mock.Mock()
+
+    rw = RW_mock()
+    rw.transport = ct
+    rw.recipe_step = {"parameters": {"images_command": "do_mrc_to_jpeg"}}
+    rw.environment = {"has_recipe_wrapper": False}
+    rw.set_default_channel = rw.dummy
+    rw.send = rw.dummy
+
+    msg = {"file": jpeg_path.replace(".jpeg", ".mrc")}
+    header = {}
+
+    class FunctionParameter(NamedTuple):
+        rw: RW_mock
+        message: dict
+        header: dict
+
+    params = FunctionParameter(rw, msg, header)
+
+    mrc_to_jpeg(params)
+
+    ct.nack.assert_not_called()
+    ct.ack.assert_called_once()
+
+    assert pathlib.Path(jpeg_path).is_file()


### PR DESCRIPTION
To display Relion output images in SynchWeb we need to convert them from mrc format to jpeg and then insert the path into ISPyB. These changes should provide the infrastructure for doing that (on the wrapper side) for CTF diagnostic plots and motion corrected micrographs. 

The conversion will be done by the DLSImages zocalo service using the `images_service_plugin` provided here. This will require changes to the implementation of the Images service. Sending messages to the service will require a change to the zocalo recipe as well.