### PR TITLE
Change Icebreaker group job to run on batches, similar to 2D classification

### DIFF
--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -2726,30 +2726,6 @@ def run_pipeline(opts):
             )
             runjobs.append(extract_job)
 
-            #### Set up Icebreaker grouping job
-            if opts.do_icebreaker_group and opts.do_icebreaker_job_group:
-                icebreaker_group_options = [
-                    "External executable: == ib_group.py",
-                    f"Input micrographs:  == {icebreaker_job_group}grouped_micrographs.star",
-                    f"Number of threads: == {opts.icebreaker_threads_number}",
-                    "Param1 - label: == o",
-                    "Param1 - value: == External/Icebreaker_group",
-                    "Param2 - label: == in_parts",
-                    f"Param2 - value: == {extract_job}particles.star",
-                ]
-                if opts.motioncor_submit_to_queue:
-                    icebreaker_group_options.extend(queue_options_cpu)
-                icebreaker_group_job, already_had_it = addJob(
-                    "External",
-                    "icebreaker_group_job",
-                    SETUP_CHECK_FILE,
-                    icebreaker_group_options,
-                    alias="Icebreaker_group",
-                )
-
-            if opts.do_icebreaker_group and opts.do_icebreaker_job_group:
-                runjobs.append(icebreaker_group_job)
-
             if (ipass == 0 and (opts.do_class2d or opts.do_class3d)) or (
                 ipass == 1 and (opts.do_class2d_pass2 or opts.do_class3d_pass2)
             ):
@@ -2960,6 +2936,51 @@ def run_pipeline(opts):
                         if (ipass == 0 and opts.do_class2d) or (
                             ipass == 1 and opts.do_class2d_pass2
                         ):
+
+                            #### Set up Icebreaker grouping job
+
+                            if (
+                                opts.do_icebreaker_group
+                                and opts.do_icebreaker_job_group
+                                and ipass == 0
+                            ):
+                                ibjobname = "icebreaker_group_job_batch_{:03d}".format(
+                                    iibatch
+                                )
+                                ibalias = "Icebreaker_group_batch_{:03d}".format(
+                                    iibatch
+                                )
+
+                                icebreaker_group_options = [
+                                    "External executable: == ib_group.py",
+                                    f"Input micrographs:  == {icebreaker_job_group}grouped_micrographs.star",
+                                    f"Number of threads: == {opts.icebreaker_threads_number}",
+                                    "Param1 - label: == o",
+                                    f"Param1 - value: == External/{ibalias}",
+                                    "Param2 - label: == in_parts",
+                                    f"Param2 - value: == {particles_star_file}",
+                                ]
+                                if opts.motioncor_submit_to_queue:
+                                    icebreaker_group_options.extend(queue_options_cpu)
+
+                                ibjobname = "icebreaker_group_job_batch_{:03d}".format(
+                                    iibatch
+                                )
+                                ibalias = "Icebreaker_group_batch_{:03d}".format(
+                                    iibatch
+                                )
+
+                                icebreaker_group_job, already_had_it = addJob(
+                                    "External",
+                                    ibjobname,
+                                    SETUP_CHECK_FILE,
+                                    icebreaker_group_options,
+                                    alias=ibalias,
+                                )
+
+                                RunJobs(
+                                    [icebreaker_group_job], 1, 1, "ICEBREAKER_GROUP"
+                                )
 
                             class2d_options = [
                                 "Input images STAR file: == {}".format(

--- a/src/relion/cryolo_relion_it/icebreaker_histogram.py
+++ b/src/relion/cryolo_relion_it/icebreaker_histogram.py
@@ -61,7 +61,6 @@ def _get_data(working_directory):
         if particles_file.is_file():
             passed.append(True)
             current_data = extract_ice_column(particles_file)
-            print(current_data)
             if not current_data:
                 logger.debug(f"No ice thickness data extracted for {particles_file}.")
             else:

--- a/src/relion/cryolo_relion_it/icebreaker_histogram.py
+++ b/src/relion/cryolo_relion_it/icebreaker_histogram.py
@@ -52,8 +52,8 @@ def create_pdf_histogram(working_directory):
 
 def _get_data(working_directory):
     data = []
-    icebreaker_paths = (working_directory / "External").glob("Icebreaker_group*")
-    if not len(list(icebreaker_paths)):
+    icebreaker_paths = list((working_directory / "External").glob("Icebreaker_group*"))
+    if not len(icebreaker_paths):
         return None
     passed = []
     for ibpath in icebreaker_paths:

--- a/src/relion/cryolo_relion_it/icebreaker_histogram.py
+++ b/src/relion/cryolo_relion_it/icebreaker_histogram.py
@@ -53,6 +53,8 @@ def create_pdf_histogram(working_directory):
 def _get_data(working_directory):
     data = []
     icebreaker_paths = (working_directory / "External").glob("Icebreaker_group*")
+    if not len(list(icebreaker_paths)):
+        return None
     passed = []
     for ibpath in icebreaker_paths:
         particles_file = ibpath / "particles.star"

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -155,7 +155,9 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                 self.recwrap.send_to("images", {"file": img})
 
             ### Extract and send Icebreaker results as histograms if the Icebreaker grouping job has run
-            if not self.opts.stop_after_ctf_estimation:
+            if not self.opts.stop_after_ctf_estimation and (
+                self.opts.do_class2d or self.opts.do_class3d
+            ):
                 attachment_list = []
                 try:
                     pdf_file_path = icebreaker_histogram.create_pdf_histogram(

--- a/tests/cryolo_relion_it/test_icebreaker_external_job.py
+++ b/tests/cryolo_relion_it/test_icebreaker_external_job.py
@@ -16,10 +16,39 @@ def test_create_json_histogram(tmp_path):
     )
 
 
+def test_create_json_histogram_more_than_one_batch(tmp_path):
+    # Prep
+    icebreaker_dir = tmp_path / "External" / "Icebreaker_group_batch_001"
+    icebreaker_dir_02 = tmp_path / "External" / "Icebreaker_group_batch_002"
+    icebreaker_dir.mkdir(parents=True)
+    icebreaker_dir_02.mkdir(parents=True)
+    particles_file = icebreaker_dir / "particles.star"
+    particles_file.write_text("")
+    particles_file_02 = icebreaker_dir_02 / "particles.star"
+    particles_file_02.write_text("")
+
+    assert (
+        icebreaker_histogram.create_json_histogram(tmp_path)
+        == icebreaker_dir / "ice_hist.json"
+    )
+
+
 def test_create_json_histogram_fails_without_particle_star_file(tmp_path):
     # Prep
     icebreaker_dir = tmp_path / "External" / "Icebreaker_group_batch_001"
     icebreaker_dir.mkdir(parents=True)
+
+    assert icebreaker_histogram.create_json_histogram(tmp_path) is None
+
+
+def test_create_json_histogram_fails_without_particle_star_file_in_any_batch(tmp_path):
+    # Prep
+    icebreaker_dir = tmp_path / "External" / "Icebreaker_group_batch_001"
+    icebreaker_dir.mkdir(parents=True)
+    particles_file = icebreaker_dir / "particles.star"
+    particles_file.write_text("")
+    icebreaker_dir_02 = tmp_path / "External" / "Icebreaker_group_batch_002"
+    icebreaker_dir_02.mkdir(parents=True)
 
     assert icebreaker_histogram.create_json_histogram(tmp_path) is None
 

--- a/tests/cryolo_relion_it/test_icebreaker_external_job.py
+++ b/tests/cryolo_relion_it/test_icebreaker_external_job.py
@@ -5,7 +5,7 @@ from relion.cryolo_relion_it import icebreaker_histogram
 
 def test_create_json_histogram(tmp_path):
     # Prep
-    icebreaker_dir = tmp_path / "External" / "Icebreaker_group"
+    icebreaker_dir = tmp_path / "External" / "Icebreaker_group_batch_001"
     icebreaker_dir.mkdir(parents=True)
     particles_file = icebreaker_dir / "particles.star"
     particles_file.write_text("")
@@ -18,7 +18,7 @@ def test_create_json_histogram(tmp_path):
 
 def test_create_json_histogram_fails_without_particle_star_file(tmp_path):
     # Prep
-    icebreaker_dir = tmp_path / "External" / "Icebreaker_group"
+    icebreaker_dir = tmp_path / "External" / "Icebreaker_group_batch_001"
     icebreaker_dir.mkdir(parents=True)
 
     assert icebreaker_histogram.create_json_histogram(tmp_path) is None
@@ -26,7 +26,7 @@ def test_create_json_histogram_fails_without_particle_star_file(tmp_path):
 
 def test_create_json_histogram_creates_a_file(tmp_path):
     # Prep
-    icebreaker_dir = tmp_path / "External" / "Icebreaker_group"
+    icebreaker_dir = tmp_path / "External" / "Icebreaker_group_batch_001"
     icebreaker_dir.mkdir(parents=True)
     particles_file = icebreaker_dir / "particles.star"
 
@@ -42,7 +42,7 @@ def test_create_json_histogram_creates_a_file(tmp_path):
 
 def test_create_pdf_histogram(tmp_path):
     # Prep
-    icebreaker_dir = tmp_path / "External" / "Icebreaker_group"
+    icebreaker_dir = tmp_path / "External" / "Icebreaker_group_batch_001"
     icebreaker_dir.mkdir(parents=True)
     particles_file = icebreaker_dir / "particles.star"
     particles_file.write_text("")
@@ -55,7 +55,7 @@ def test_create_pdf_histogram(tmp_path):
 
 def test_create_pdf_histogram_fails_without_particle_star_file(tmp_path):
     # Prep
-    icebreaker_dir = tmp_path / "External" / "Icebreaker_group"
+    icebreaker_dir = tmp_path / "External" / "Icebreaker_group_batch_001"
     icebreaker_dir.mkdir(parents=True)
 
     assert icebreaker_histogram.create_pdf_histogram(tmp_path) is None
@@ -63,7 +63,7 @@ def test_create_pdf_histogram_fails_without_particle_star_file(tmp_path):
 
 def test_create_pdf_histogram_creates_a_file(tmp_path):
     # Prep
-    icebreaker_dir = tmp_path / "External" / "Icebreaker_group"
+    icebreaker_dir = tmp_path / "External" / "Icebreaker_group_batch_001"
     icebreaker_dir.mkdir(parents=True)
     particles_file = icebreaker_dir / "particles.star"
     out_doc = gemmi.cif.Document()

--- a/tests/cryolo_relion_it/test_icebreaker_external_job.py
+++ b/tests/cryolo_relion_it/test_icebreaker_external_job.py
@@ -17,7 +17,6 @@ def test_create_json_histogram(tmp_path):
 
 
 def test_create_json_histogram_more_than_one_batch(tmp_path):
-    # Prep
     icebreaker_dir = tmp_path / "External" / "Icebreaker_group_batch_001"
     icebreaker_dir_02 = tmp_path / "External" / "Icebreaker_group_batch_002"
     icebreaker_dir.mkdir(parents=True)


### PR DESCRIPTION
The Icebreaker group job currently runs on the `particles.star` output of the Extract job meaning it slows down as more data is collected. Solve this by running on batches and moving to a different schedule so that it doesn't slow down preprocessing