### PR TITLE
Add EER file format support to the pipeline

### DIFF
--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -600,6 +600,8 @@ class RelionItOptions(object):
     motioncor_doseperframe = 1.277
     # Gain-reference image in MRC format (only necessary if input movies are not yet gain-corrected, e.g. compressed TIFFs from K2)
     motioncor_gainreference = "Movies/gain.mrc"
+    eer_upsampling = 1
+    eer_grouping = 20
 
     ### CTF estimation parameters
     # Most cases won't need changes here...
@@ -2391,6 +2393,9 @@ def run_pipeline(opts):
             ]
 
             if opts.motioncor_do_own:
+                motioncorr_options.append(
+                    f"Additional arguments: == --eer_upsampling {opts.eer_upsampling} --eer_grouping {opts.eer_grouping}"
+                )
                 motioncorr_options.append("Use RELION's own implementation? == Yes")
                 if opts.use_ctffind_instead:
                     motioncorr_options.append("Save sum of power spectra? == Yes")

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -110,6 +110,9 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                     self.params["ispyb_parameters"][k] = float(v)
                 except ValueError:
                     pass
+
+        if self.params["ispyb_parameters"]["import_images"].endswith(".eer"):
+            self.params["ispyb_parameters"]["motioncor_do_own"] = True
         pprint(self.params["ispyb_parameters"])
 
         self.opts = RelionItOptions()


### PR DESCRIPTION
Adds the necessary additional options to `RelionItOptions` and runs Relion's own motion correction if the wrapper finds that the `import_images` parameter has a `.eer` extension.