### PR TITLE
Add image service plugin to make particle picker images

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ zocalo.wrappers =
     relion = relion.zocalo.wrapper:RelionWrapper
 zocalo.services.images.plugins = 
     mrc_to_jpeg = relion.zocalo.images_service_plugin:mrc_to_jpeg
+    picked_particles = relion.zocalo.images_service_plugin:picked_particles
 
 [options.packages.find]
 where = src

--- a/src/relion/_parser/autopick.py
+++ b/src/relion/_parser/autopick.py
@@ -11,6 +11,7 @@ ParticlePickerInfo = namedtuple(
     [
         "number_of_particles",
         "micrograph_full_path",
+        "mc_image_full_path",
         "first_micrograph_name",
         "highlighted_micrograph",
         "coordinates",
@@ -82,6 +83,7 @@ class AutoPick(JobType):
                 ParticlePickerInfo(
                     int(np),
                     mic,
+                    str(self._basepath.parent / mic).replace(".mrc", ".jpeg"),
                     first_mc_micrograph,
                     str(highlighted_micrograph),
                     coords,
@@ -153,6 +155,7 @@ class AutoPick(JobType):
                 "number_of_particles": pi.number_of_particles,
                 "job_string": pi.job,
                 "micrograph_full_path": pi.micrograph_full_path,
+                "mc_image_full_path": pi.mc_image_full_path,
                 "summary_image_full_path": pi.highlighted_micrograph,
                 "particle_coordinates": pi.coordinates,
             }

--- a/src/relion/_parser/autopick.py
+++ b/src/relion/_parser/autopick.py
@@ -97,7 +97,9 @@ class AutoPick(JobType):
         particle_data = []
         particle_star_file = pathlib.Path(
             str(
-                micrograph.relative_to(micrograph.parent.parent).with_suffix(".star")
+                micrograph.relative_to(micrograph.parent.parent.parent).with_suffix(
+                    ".star"
+                )
             ).replace(micrograph.stem, micrograph.stem + "_autopick")
         )
         if self._particle_cache.get(jobdir):

--- a/src/relion/_parser/autopick.py
+++ b/src/relion/_parser/autopick.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 from collections import namedtuple
 
 from relion._parser.jobtype import JobType
@@ -11,6 +12,7 @@ ParticlePickerInfo = namedtuple(
         "number_of_particles",
         "micrograph_full_path",
         "first_micrograph_name",
+        "highlighted_micrograph",
         "job",
     ],
 )
@@ -51,8 +53,22 @@ class AutoPick(JobType):
 
         particle_picker_info = []
         for mic, np in zip(mc_micrographs, all_particles):
+            mic_parts = pathlib.Path(mic).parts
+            highlighted_micrograph = (
+                self._basepath
+                / jobdir
+                / pathlib.Path(mic)
+                .relative_to(pathlib.Path(mic_parts[0]) / mic_parts[1])
+                .with_suffix(".jpeg")
+            )
             particle_picker_info.append(
-                ParticlePickerInfo(int(np), mic, first_mc_micrograph, jobdir)
+                ParticlePickerInfo(
+                    int(np),
+                    mic,
+                    first_mc_micrograph,
+                    str(highlighted_micrograph),
+                    jobdir,
+                )
             )
 
         return particle_picker_info
@@ -68,6 +84,7 @@ class AutoPick(JobType):
                 "number_of_particles": pi.number_of_particles,
                 "job_string": pi.job,
                 "micrograph_full_path": pi.micrograph_full_path,
+                "highlighted_micrograph_full_path": pi.highlighted_micrograph,
             }
             for pi in partpickinfo
         ]

--- a/src/relion/_parser/autopick.py
+++ b/src/relion/_parser/autopick.py
@@ -84,7 +84,7 @@ class AutoPick(JobType):
                 "number_of_particles": pi.number_of_particles,
                 "job_string": pi.job,
                 "micrograph_full_path": pi.micrograph_full_path,
-                "highlighted_micrograph_full_path": pi.highlighted_micrograph,
+                "summary_image_full_path": pi.highlighted_micrograph,
             }
             for pi in partpickinfo
         ]

--- a/src/relion/_parser/autopick.py
+++ b/src/relion/_parser/autopick.py
@@ -95,12 +95,12 @@ class AutoPick(JobType):
 
     def _get_particle_info(self, jobdir, micrograph):
         particle_data = []
+        mic_parts = micrograph.parts
+        mc_job_path = pathlib.Path(mic_parts[0]) / mic_parts[1]
         particle_star_file = pathlib.Path(
-            str(
-                micrograph.relative_to(micrograph.parent.parent.parent).with_suffix(
-                    ".star"
-                )
-            ).replace(micrograph.stem, micrograph.stem + "_autopick")
+            str(micrograph.relative_to(mc_job_path).with_suffix(".star")).replace(
+                micrograph.stem, micrograph.stem + "_autopick"
+            )
         )
         if self._particle_cache.get(jobdir):
             if self._particle_cache[jobdir].get(micrograph):

--- a/src/relion/_parser/autopick.py
+++ b/src/relion/_parser/autopick.py
@@ -31,10 +31,7 @@ ParticleCacheRecord = namedtuple(
 class AutoPick(JobType):
     def __init__(self, path, particle_cache=None):
         super().__init__(path)
-        if particle_cache is None:
-            self._particle_cache = {}
-        else:
-            self._particle_cache = particle_cache
+        self._particle_cache = particle_cache or {}
 
     def __eq__(self, other):
         if isinstance(other, AutoPick):  # check this

--- a/src/relion/_parser/cryolo.py
+++ b/src/relion/_parser/cryolo.py
@@ -1,13 +1,20 @@
 import logging
 import pathlib
 
-from relion._parser.autopick import ParticlePickerInfo
+from relion._parser.autopick import ParticleCacheRecord, ParticlePickerInfo
 from relion._parser.jobtype import JobType
 
 logger = logging.getLogger("relion._parser.cryolo")
 
 
 class Cryolo(JobType):
+    def __init__(self, path, particle_cache=None):
+        super().__init__(path)
+        if particle_cache is None:
+            self._particle_cache = {}
+        else:
+            self._particle_cache = particle_cache
+
     def __eq__(self, other):
         if isinstance(other, Cryolo):  # check this
             return self._basepath == other._basepath
@@ -34,27 +41,16 @@ class Cryolo(JobType):
         num_particles = 0
         particles_per_micrograph = {}
         first_mic = ""
+        coords = {}
         for star_file in (self._basepath / jobdir / "Movies").glob("**/*"):
             if star_file.is_file() and "gain" not in str(star_file):
-                try:
-                    file = self._read_star_file(
-                        jobdir, star_file.relative_to(self._basepath / jobdir)
-                    )
-                except (RuntimeError, FileNotFoundError, OSError, ValueError):
-                    continue
-
-                info_table = self._find_table_from_column_name("_rlnCoordinateX", file)
-                if info_table is None:
-                    logger.debug(f"_rlnCoordinateX not found in file {file}")
-                    continue
-
-                all_particles = self.parse_star_file(
-                    "_rlnCoordinateX", file, info_table
-                )
-                if particles_per_micrograph == {}:
-                    first_mic = star_file
-                particles_per_micrograph[star_file] = len(all_particles)
-                num_particles += len(all_particles)
+                part_coords = self._get_particle_info(jobdir, star_file)
+                if part_coords:
+                    coords[star_file] = part_coords
+                    if particles_per_micrograph == {}:
+                        first_mic = star_file
+                    particles_per_micrograph[star_file] = len(part_coords)
+                    num_particles += len(part_coords)
 
         # all of this just tracks back to a micrograph name from the MotionCorrection job
         try:
@@ -99,11 +95,53 @@ class Cryolo(JobType):
                         "_autopick.star", ".mrc"
                     ),
                     str(highlighted_micrograph),
+                    coords[mic],
                     jobdir,
                 )
             )
 
         return particle_picker_info
+
+    def _get_particle_info(self, jobdir, star_file):
+        if self._particle_cache.get(jobdir) is None:
+            self._particle_cache[jobdir] = {}
+        if self._particle_cache[jobdir].get(star_file):
+            try:
+                if (
+                    self._particle_cache[jobdir][star_file].file_size
+                    == star_file.stat().st_size
+                ):
+                    return self._particle_cache[jobdir][star_file].data
+            except FileNotFoundError:
+                logger.debug(
+                    "Could not find expected file containing particle data",
+                    exc_info=True,
+                )
+                return []
+
+        try:
+            file = self._read_star_file(
+                jobdir, star_file.relative_to(self._basepath / jobdir)
+            )
+        except (RuntimeError, FileNotFoundError, OSError, ValueError):
+            return []
+
+        info_table = self._find_table_from_column_name("_rlnCoordinateX", file)
+        if info_table is None:
+            logger.debug(f"_rlnCoordinateX not found in file {file}")
+            return []
+
+        all_particles = self.parse_star_file("_rlnCoordinateX", file, info_table)
+        ys = self.parse_star_file("_rlnCoordinateY", file, info_table)
+        coords = [(x, y) for x, y in zip(all_particles, ys)]
+        try:
+            self._particle_cache[jobdir][star_file] = ParticleCacheRecord(
+                coords,
+                star_file.stat().st_size,
+            )
+        except FileNotFoundError:
+            return []
+        return coords
 
     def _get_micrograph_name(self, micrograph, micrograph_names, jobdir):
         for x in micrograph_names:
@@ -128,6 +166,7 @@ class Cryolo(JobType):
                 "job_string": pi.job,
                 "micrograph_full_path": pi.micrograph_full_path,
                 "summary_image_full_path": pi.highlighted_micrograph,
+                "particle_coordinates": pi.coordinates,
             }
             for pi in partpickinfo
         ]

--- a/src/relion/_parser/cryolo.py
+++ b/src/relion/_parser/cryolo.py
@@ -127,7 +127,7 @@ class Cryolo(JobType):
                 "number_of_particles": pi.number_of_particles,
                 "job_string": pi.job,
                 "micrograph_full_path": pi.micrograph_full_path,
-                "highlighted_micrograph_full_path": pi.highlighted_micrograph,
+                "summary_image_full_path": pi.highlighted_micrograph,
             }
             for pi in partpickinfo
         ]

--- a/src/relion/_parser/cryolo.py
+++ b/src/relion/_parser/cryolo.py
@@ -83,6 +83,14 @@ class Cryolo(JobType):
 
         particle_picker_info = []
         for mic, num_particles in particles_per_micrograph.items():
+            mic_parts = pathlib.Path(mic).parts
+            highlighted_micrograph = (
+                self._basepath
+                / jobdir
+                / pathlib.Path(mic)
+                .relative_to(pathlib.Path(mic_parts[0]) / mic_parts[1])
+                .with_suffix(".jpeg")
+            )
             particle_picker_info.append(
                 ParticlePickerInfo(
                     num_particles,
@@ -90,6 +98,7 @@ class Cryolo(JobType):
                     str(first_mic.relative_to(self._basepath / jobdir)).replace(
                         "_autopick.star", ".mrc"
                     ),
+                    str(highlighted_micrograph),
                     jobdir,
                 )
             )
@@ -118,6 +127,7 @@ class Cryolo(JobType):
                 "number_of_particles": pi.number_of_particles,
                 "job_string": pi.job,
                 "micrograph_full_path": pi.micrograph_full_path,
+                "highlighted_micrograph_full_path": pi.highlighted_micrograph,
             }
             for pi in partpickinfo
         ]

--- a/src/relion/_parser/cryolo.py
+++ b/src/relion/_parser/cryolo.py
@@ -87,10 +87,12 @@ class Cryolo(JobType):
                 .relative_to(pathlib.Path(mic_parts[0]) / mic_parts[1])
                 .with_suffix(".jpeg")
             )
+            mc_mic_name = (self._get_micrograph_name(mic, micrograph_names, jobdir),)
             particle_picker_info.append(
                 ParticlePickerInfo(
                     num_particles,
-                    self._get_micrograph_name(mic, micrograph_names, jobdir),
+                    mc_mic_name,
+                    str(self._basepath.parent / mc_mic_name).replace(".mrc", ".jpeg"),
                     str(first_mic.relative_to(self._basepath / jobdir)).replace(
                         "_autopick.star", ".mrc"
                     ),
@@ -165,6 +167,7 @@ class Cryolo(JobType):
                 "number_of_particles": pi.number_of_particles,
                 "job_string": pi.job,
                 "micrograph_full_path": pi.micrograph_full_path,
+                "mc_image_full_path": pi.mc_image_full_path,
                 "summary_image_full_path": pi.highlighted_micrograph,
                 "particle_coordinates": pi.coordinates,
             }

--- a/src/relion/dbmodel/modeltables.py
+++ b/src/relion/dbmodel/modeltables.py
@@ -214,6 +214,7 @@ class ParticlePickerTable(Table):
         columns.extend(
             [
                 "micrograph_full_path",
+                "particle_coordinates",
                 "job_string",
             ]
         )

--- a/src/relion/dbmodel/modeltables.py
+++ b/src/relion/dbmodel/modeltables.py
@@ -214,6 +214,7 @@ class ParticlePickerTable(Table):
         columns.extend(
             [
                 "micrograph_full_path",
+                "mc_image_full_path",
                 "particle_coordinates",
                 "job_string",
             ]

--- a/src/relion/dbmodel/modeltables.py
+++ b/src/relion/dbmodel/modeltables.py
@@ -214,7 +214,6 @@ class ParticlePickerTable(Table):
         columns.extend(
             [
                 "micrograph_full_path",
-                "highlighted_micrograph_full_path",
                 "job_string",
             ]
         )

--- a/src/relion/dbmodel/modeltables.py
+++ b/src/relion/dbmodel/modeltables.py
@@ -214,6 +214,7 @@ class ParticlePickerTable(Table):
         columns.extend(
             [
                 "micrograph_full_path",
+                "highlighted_micrograph_full_path",
                 "job_string",
             ]
         )

--- a/src/relion/zocalo/images_service_plugin.py
+++ b/src/relion/zocalo/images_service_plugin.py
@@ -26,7 +26,7 @@ def mrc_to_jpeg(plugin_params):
         logger.error(
             "File {filepath} could not be opened. It may be corrupted or not in mrc format"
         )
-        return
+        return None
     data = data - data.min()
     data = data * 255 / data.max()
     data = data.astype(np.uint8)

--- a/src/relion/zocalo/images_service_plugin.py
+++ b/src/relion/zocalo/images_service_plugin.py
@@ -4,6 +4,7 @@ import pathlib
 import mrcfile
 import numpy as np
 import PIL.Image
+from PIL import ImageDraw, ImageEnhance, ImageFilter
 
 logger = logging.getLogger("relion.zocalo.images_service_plugin")
 
@@ -13,11 +14,11 @@ def mrc_to_jpeg(plugin_params):
     allframes = plugin_params.parameters("all_frames")
     if not filename or filename == "None":
         logger.debug("Skipping mrc to jpeg conversion: filename not specified")
-        return
+        return None
     filepath = pathlib.Path(filename)
     if not filepath.is_file():
         logger.error(f"File {filepath} not found")
-        return
+        return None
     try:
         with mrcfile.open(filepath) as mrc:
             data = mrc.data
@@ -48,4 +49,33 @@ def mrc_to_jpeg(plugin_params):
     logger.info(f"Converted mrc to jpeg {filename} -> {outfile}")
     if outfiles:
         return outfiles
+    return outfile
+
+
+def picked_particles(plugin_params):
+    basefilename = plugin_params.parameters("file")
+    coords = plugin_params.parameters("coordinates")
+    angpix = plugin_params.parameters("angpix")
+    diam = plugin_params.parameters("diameter")
+    contrast_factor = plugin_params.parameters("contrast_factor", default=6)
+    outfile = plugin_params.parameters("outfile")
+    if not outfile:
+        logger.warning(f"Outfile incorrectly specified: {outfile}")
+        return None
+    radius = (diam / angpix) // 2
+    try:
+        with PIL.Image.open(basefilename) as bim:
+            enhancer = ImageEnhance.Contrast(bim)
+            enhanced = enhancer.enhance(contrast_factor)
+            fim = enhanced.filter(ImageFilter.BLUR)
+            dim = ImageDraw.Draw(fim)
+            for x, y in coords:
+                dim.ellipse(
+                    [(x - radius, y - radius), (x + radius, y + radius)],
+                    width=8,
+                    outline="#f58a07",
+                )
+            dim.save(outfile)
+    except FileNotFoundError:
+        logger.error(f"File {basefilename} could not be opened")
     return outfile

--- a/src/relion/zocalo/images_service_plugin.py
+++ b/src/relion/zocalo/images_service_plugin.py
@@ -62,6 +62,9 @@ def picked_particles(plugin_params):
     if not outfile:
         logger.warning(f"Outfile incorrectly specified: {outfile}")
         return None
+    if not basefilename.is_file():
+        logger.error(f"File {basefilename} not found")
+        return None
     radius = (diam / angpix) // 2
     try:
         with PIL.Image.open(basefilename).convert(mode="RGB") as bim:

--- a/src/relion/zocalo/images_service_plugin.py
+++ b/src/relion/zocalo/images_service_plugin.py
@@ -64,18 +64,22 @@ def picked_particles(plugin_params):
         return None
     radius = (diam / angpix) // 2
     try:
-        with PIL.Image.open(basefilename) as bim:
+        with PIL.Image.open(basefilename).convert(mode="RGB") as bim:
             enhancer = ImageEnhance.Contrast(bim)
             enhanced = enhancer.enhance(contrast_factor)
             fim = enhanced.filter(ImageFilter.BLUR)
             dim = ImageDraw.Draw(fim)
             for x, y in coords:
                 dim.ellipse(
-                    [(x - radius, y - radius), (x + radius, y + radius)],
+                    [
+                        (float(x) - radius, float(y) - radius),
+                        (float(x) + radius, float(y) + radius),
+                    ],
                     width=8,
                     outline="#f58a07",
                 )
-            dim.save(outfile)
+            fim.save(outfile)
+            logger.info(f"Particle picker image {outfile} saved")
     except FileNotFoundError:
         logger.error(f"File {basefilename} could not be opened")
     return outfile

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -466,7 +466,7 @@ def images_particles_msgs(table, primary_key, **kwargs):
 
 @images_particles_msgs.register(ParticlePickerTable)
 def _(table: ParticlePickerTable, primary_key: int, **kwargs):
-    mc_image_path = table.get_row_by_primary_key(primary_key)["micrograph_full_path"]
+    mc_image_path = table.get_row_by_primary_key(primary_key)["mc_image_full_path"]
     parpick_image_path = table.get_row_by_primary_key(primary_key)[
         "summary_image_full_path"
     ]

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -468,7 +468,7 @@ def images_particles_msgs(table, primary_key, **kwargs):
 def _(table: ParticlePickerTable, primary_key: int, **kwargs):
     mc_image_path = table.get_row_by_primary_key(primary_key)["micrograph_full_path"]
     parpick_image_path = table.get_row_by_primary_key(primary_key)[
-        "highlighted_micrograph_full_path"
+        "summary_image_full_path"
     ]
     if not mc_image_path or not parpick_image_path:
         return {}

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -225,6 +225,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                             "diameter": self.opts.mask_diameter,
                         }
                     )
+                    self.recwrap.send_to("images_particles", imgcmd)
 
             ### Extract and send Icebreaker results as histograms if the Icebreaker grouping job has run
             if not self.opts.stop_after_ctf_estimation and (

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -133,6 +133,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
             message_constructors={
                 "ispyb": construct_message,
                 "images": images_msgs,
+                "images_particles": images_particles_msgs,
             },
         )
 
@@ -157,6 +158,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
             ispyb_command_list = []
             images_command_list = []
+            images_particles_command_list = []
 
             if pathlib.Path(self.params["stop_file"]).is_file():
                 relion_prj.load()
@@ -199,6 +201,8 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                     ispyb_command_list.extend(job_msg["ispyb"])
                 if job_msg.get("images") and job_msg["images"]:
                     images_command_list.extend(job_msg["images"])
+                if job_msg.get("images_particles") and job_msg["images_particles"]:
+                    images_particles_command_list.extend(job_msg["images_particles"])
 
             if ispyb_command_list:
                 logger.info(
@@ -212,6 +216,15 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
             for imgcmd in images_command_list:
                 if imgcmd:
                     self.recwrap.send_to("images", imgcmd)
+
+            for imgcmd in images_particles_command_list:
+                if imgcmd:
+                    imgcmd.update(
+                        {
+                            "angpix": self.opts.angpix,
+                            "diameter": self.opts.mask_diameter,
+                        }
+                    )
 
             ### Extract and send Icebreaker results as histograms if the Icebreaker grouping job has run
             if not self.opts.stop_after_ctf_estimation and (
@@ -416,7 +429,6 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
 @functools.singledispatch
 def images_msgs(table, primary_key, **kwargs):
-    logger.debug(f"{table!r} does not have associated images")
     return []
 
 
@@ -447,175 +459,20 @@ def _(table: ParticleClassificationGroupTable, primary_key: int, **kwargs):
 
 
 @functools.singledispatch
-def ispyb_results(
-    relion_stage_object, job_string: str, relion_options: RelionItOptions
-):
-    """
-    A function that takes Relion stage objects and job names (together
-    representing a single job directory) and translates them into ISPyB
-    service commands.
-    """
-    raise ValueError(f"{relion_stage_object!r} is not a known Relion object")
-
-
-@ispyb_results.register(relion.InitialModel)
-def _(
-    stage_object: relion.InitialModel, job_string: str, relion_options: RelionItOptions
-):
+def images_particles_msgs(table, primary_key, **kwargs):
     return []
 
 
-@ispyb_results.register(relion.CTFFind)
-def _(stage_object: relion.CTFFind, job_string: str, relion_options: RelionItOptions):
-    logger.info("Generating ISPyB commands for %s ", job_string)
-    ispyb_command_list = []
-    for ctf_micrograph in stage_object[job_string]:
-        ispyb_command_list.append(
-            {
-                "ispyb_command": "insert_ctf",
-                "micrograph_name": ctf_micrograph.micrograph_name,
-                "astigmatism": ctf_micrograph.astigmatism,
-                "astigmatism_angle": ctf_micrograph.defocus_angle,
-                "max_estimated_resolution": ctf_micrograph.max_resolution,
-                "estimated_defocus": (
-                    float(ctf_micrograph.defocus_u) + float(ctf_micrograph.defocus_v)
-                )
-                / 2,
-                "cc_value": ctf_micrograph.fig_of_merit,
-                "amplitude_contrast": ctf_micrograph.amp_contrast,
-                "fft_theoretical_full_path": ctf_micrograph.diagnostic_plot_path,
-                "box_size_x": relion_options.ctffind_boxsize,
-                "box_size_y": relion_options.ctffind_boxsize,
-                "min_resolution": relion_options.ctffind_minres,
-                "max_resolution": relion_options.ctffind_maxres,
-                "min_defocus": relion_options.ctffind_defocus_min,
-                "max_defocus": relion_options.ctffind_defocus_max,
-                "defocus_step_size": relion_options.ctffind_defocus_step,
-            }
-        )
-    return ispyb_command_list
-
-
-@ispyb_results.register(relion.MotionCorr)
-def _(
-    stage_object: relion.MotionCorr, job_string: str, relion_options: RelionItOptions
-):
-    logger.info("Generating ISPyB commands for %s ", job_string)
-    ispyb_command_list = []
-    for motion_corr_micrograph in stage_object[job_string]:
-        number_of_frames = len(motion_corr_micrograph.drift_data)
-        ispyb_command_list.append(
-            {
-                "ispyb_command": "insert_motion_correction",
-                "micrograph_name": motion_corr_micrograph.micrograph_name,
-                "total_motion": motion_corr_micrograph.total_motion,
-                "early_motion": motion_corr_micrograph.early_motion,
-                "late_motion": motion_corr_micrograph.late_motion,
-                "average_motion_per_frame": (float(motion_corr_micrograph.total_motion))
-                / number_of_frames,
-                "dose_per_frame": relion_options.motioncor_doseperframe,
-                "patches_used_x": relion_options.motioncor_patches_x,
-                "patches_used_y": relion_options.motioncor_patches_y,
-                "image_number": motion_corr_micrograph.micrograph_number,
-                "micrograph_snapshot_full_path": motion_corr_micrograph.micrograph_snapshot_full_path,
-                "drift_frames": [
-                    (frame.frame, frame.deltaX, frame.deltaY)
-                    for frame in motion_corr_micrograph.drift_data
-                ],
-            }
-        )
-    return ispyb_command_list
-
-
-@ispyb_results.register(relion.AutoPick)
-def _(stage_object: relion.AutoPick, job_string: str, relion_options: RelionItOptions):
-    ispyb_command_list = [
-        {
-            "ispyb_command": "insert_particle_picker",
-            "number_of_particles": mic.number_of_particles,
-            "particle_diameter": relion_options.autopick_LoG_diam_max
-            / 10,  # units are nm not Angstrom in the DB
-            "micrograph_name": mic.micrograph_full_path,
-        }
-        for mic in stage_object[job_string]
+@images_particles_msgs.register(ParticlePickerTable)
+def _(table: ParticlePickerTable, primary_key: int, **kwargs):
+    mc_image_path = table.get_row_by_primary_key(primary_key)["micrograph_full_path"]
+    parpick_image_path = table.get_row_by_primary_key(primary_key)[
+        "highlighted_micrograph_full_path"
     ]
-    return ispyb_command_list
-
-
-@ispyb_results.register(relion.Cryolo)
-def _(stage_object: relion.Cryolo, job_string: str, relion_options: RelionItOptions):
-    ispyb_command_list = [
-        {
-            "ispyb_command": "insert_particle_picker",
-            "number_of_particles": mic.number_of_particles,
-            "particle_diameter": int(
-                relion_options.extract_boxsize
-                * relion_options.angpix
-                / relion_options.motioncor_binning
-            )
-            / 10,
-            "particle_picking_template": relion_options.cryolo_gmodel,
-            "micrograph_name": mic.micrograph_full_path,
-        }
-        for mic in stage_object[job_string]
-    ]
-    return ispyb_command_list
-
-
-@ispyb_results.register(relion.Class2D)
-def _(stage_object: relion.Class2D, job_string: str, relion_options: RelionItOptions):
-    ispyb_command_list = []
-    sorted_jobs = sorted(
-        [st for st in stage_object.keys()], key=lambda st: int(st.replace("job", ""))
-    )
-    batch_number = sorted_jobs.index(job_string) + 1
-    for class_2d in stage_object[job_string]:
-        ispyb_command_list.append(
-            {
-                "ispyb_command": "insert_class2d",
-                "number_of_particles_per_batch": relion_options.batch_size,
-                "number_of_classes_per_batch": relion_options.class2d_nr_classes,
-                "type": "2D",
-                "symmetry": relion_options.symmetry,
-                "class_number": class_2d.particle_sum[0],
-                "particles_per_class": class_2d.particle_sum[1],
-                "rotation_accuracy": class_2d.accuracy_rotations,
-                "translation_accuracy": class_2d.accuracy_translations_angst,
-                "estimated_resolution": class_2d.estimated_resolution,
-                "overall_fourier_completeness": class_2d.overall_fourier_completeness,
-                "batch_number": batch_number,
-            }
-        )
-    return ispyb_command_list
-
-
-@ispyb_results.register(relion.Class3D)
-def _(stage_object: relion.Class3D, job_string: str, relion_options: RelionItOptions):
-    ispyb_command_list = []
-    sorted_jobs = sorted(
-        [st for st in stage_object.keys()], key=lambda st: int(st.replace("job", ""))
-    )
-    batch_number = sorted_jobs.index(job_string) + 1
-    for class_3d in stage_object[job_string]:
-        ispyb_command_list.append(
-            {
-                "ispyb_command": "insert_class3d",
-                "number_of_particles_per_batch": relion_options.batch_size,
-                "number_of_classes_per_batch": relion_options.class3d_nr_classes,
-                "type": "3D",
-                "symmetry": relion_options.symmetry,
-                "class_number": class_3d.particle_sum[0],
-                "particles_per_class": class_3d.particle_sum[1],
-                "rotation_accuracy": class_3d.accuracy_rotations,
-                "translation_accuracy": class_3d.accuracy_translations_angst,
-                "estimated_resolution": class_3d.estimated_resolution,
-                "overall_fourier_completeness": class_3d.overall_fourier_completeness,
-                "batch_number": batch_number,
-                "init_model_number_of_particles": class_3d.initial_model_num_particles,
-                "init_model_resolution": relion_options.inimodel_resol_final,
-            }
-        )
-    return ispyb_command_list
+    if not mc_image_path or not parpick_image_path:
+        return {}
+    coords = table.get_row_by_primary_key(primary_key)["particle_coordinates"]
+    return {"file": mc_image_path, "outfile": parpick_image_path, "coordinates": coords}
 
 
 @functools.singledispatch

--- a/tests/parser/test_autopick.py
+++ b/tests/parser/test_autopick.py
@@ -95,11 +95,18 @@ def test_number_of_particles_value(input):
     assert ap_object["job011"][0].number_of_particles == 422
 
 
-def test_micrograph_path_name(input):
+def test_micrograph_path_name(input, proj):
     ap_object = input
     assert (
         ap_object["job006"][0].first_micrograph_name
         == "MotionCorr/job002/Movies/20170629_00021_frameImage.mrc"
+    )
+    assert ap_object["job006"][0].highlighted_micrograph == str(
+        proj.basepath
+        / "AutoPick"
+        / "job006"
+        / "Movies"
+        / "20170629_00021_frameImage.jpeg"
     )
 
 

--- a/tests/zocalo/test_images_service_plugin.py
+++ b/tests/zocalo/test_images_service_plugin.py
@@ -5,9 +5,10 @@ from typing import Any, Callable, Dict, NamedTuple
 import mrcfile
 import numpy as np
 import pytest
+from PIL import Image
 
 import relion
-from relion.zocalo.images_service_plugin import mrc_to_jpeg
+from relion.zocalo.images_service_plugin import mrc_to_jpeg, picked_particles
 
 
 class FunctionParameter(NamedTuple):
@@ -28,6 +29,21 @@ def plugin_params(jpeg_path):
             "file": jpeg_path.with_suffix(".mrc"),
         }
         return p.get(key)
+
+    return FunctionParameter(rw=None, parameters=params, message={})
+
+
+def plugin_params_parpick(jpeg_path, outfile):
+    def params(key, default=None):
+        p = {
+            "parameters": {"images_command": "picked_particles"},
+            "file": jpeg_path,
+            "coordinates": [("0", "1"), ("2", "2")],
+            "angpix": 0.5,
+            "diameter": 190,
+            "outfile": outfile,
+        }
+        return p.get(key) or default
 
     return FunctionParameter(rw=None, parameters=params, message={})
 
@@ -78,3 +94,16 @@ def test_mrc_to_jpeg_ack_when_file_exists(tmp_path):
     assert mrc_to_jpeg(plugin_params(jpeg_path)) == jpeg_path
 
     assert jpeg_path.is_file()
+
+
+def test_picked_particles_processes_when_basefile_exists(tmp_path):
+    base_jpeg_path = tmp_path / "base.jpeg"
+    out_jpeg_path = tmp_path / "processed.jpeg"
+    test_data = np.arange(9, dtype=np.int8).reshape(3, 3)
+    bimg = Image.fromarray(test_data, mode="L")
+    bimg.save(base_jpeg_path)
+
+    assert (
+        picked_particles(plugin_params_parpick(base_jpeg_path, out_jpeg_path))
+        == out_jpeg_path
+    )

--- a/tests/zocalo/test_images_service_plugin.py
+++ b/tests/zocalo/test_images_service_plugin.py
@@ -107,3 +107,12 @@ def test_picked_particles_processes_when_basefile_exists(tmp_path):
         picked_particles(plugin_params_parpick(base_jpeg_path, out_jpeg_path))
         == out_jpeg_path
     )
+
+
+def test_picked_particles_returns_None_when_basefile_does_not_exist(tmp_path):
+    base_jpeg_path = tmp_path / "base.jpeg"
+    out_jpeg_path = tmp_path / "processed.jpeg"
+
+    assert (
+        picked_particles(plugin_params_parpick(base_jpeg_path, out_jpeg_path)) is None
+    )


### PR DESCRIPTION
The plugin requires a background image, for which we use the motion corrected jpegs that should already exist, and a set of particle coordinates (as well as information on the diameter). Particle coordinates are collected from files and are cached to avoid repeated file scraping in a manner analogous to what is already done for motion correction drift data.