### PR TITLE
Add ISPyB package dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ project-urls =
 include_package_data = True
 install_requires =
     gemmi
+    ispyb
     matplotlib
     mrcfile
     numpy


### PR DESCRIPTION
[`src/relion/dbmodel/modeltables.py`](https://github.com/DiamondLightSource/python-relion/blob/21161b1b297318a3591fbafb0bd9d123c54f0457/src/relion/dbmodel/modeltables.py#L5) currently [requires presence of `ispyb` (and `sqlalchemy`)](https://github.com/conda-forge/staged-recipes/pull/16055/checks?check_run_id=3494153661):
```
import: 'relion'
Traceback (most recent call last):
  File "/home/conda/staged-recipes/build_artifacts/python-relion_1630575425399/test_tmp/run_test.py", line 2, in <module>
    import relion
  File "/home/conda/staged-recipes/build_artifacts/python-relion_1630575425399/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.9/site-packages/relion/__init__.py", line 29, in <module>
    from relion.dbmodel import DBGraph, DBModel, DBNode
  File "/home/conda/staged-recipes/build_artifacts/python-relion_1630575425399/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.9/site-packages/relion/dbmodel/__init__.py", line 4, in <module>
    from relion.dbmodel.dbnode import DBNode
  File "/home/conda/staged-recipes/build_artifacts/python-relion_1630575425399/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.9/site-packages/relion/dbmodel/dbnode.py", line 3, in <module>
    from relion.dbmodel import modeltables
  File "/home/conda/staged-recipes/build_artifacts/python-relion_1630575425399/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.9/site-packages/relion/dbmodel/modeltables.py", line 5, in <module>
    from ispyb import sqlalchemy
ModuleNotFoundError: No module named 'ispyb'

```

I guess an alternative would be to hard-code here what we would otherwise interpret from the ispyb schema, and test that against the ispyb package (or the ispyb database schema) for consistency.