### PR TITLE
Add movie creation time stamps to ISPyB service message

### DIFF
--- a/src/relion/_parser/jobtype.py
+++ b/src/relion/_parser/jobtype.py
@@ -77,6 +77,11 @@ class JobType(collections.abc.Mapping):
             print("Warning - no values found for", loop_name)
         return values_list
 
+    def parse_star_file_pair(self, key, star_doc, block_number):
+        data_block = star_doc[block_number]
+        value = data_block.find_pair(key)[-1]
+        return value
+
     @staticmethod
     def _find_table_from_column_name(cname, star_doc):
         for block_index, block in enumerate(star_doc):

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -111,7 +111,7 @@ class MotionCorr(JobType):
                     accum_motion_total[j],
                     accum_motion_early[j],
                     accum_motion_late[j],
-                    (self._basepath / movie_name).stat().st_ctime,
+                    (self._basepath / movie_name).resolve().stat().st_ctime,
                     drift_data,
                 )
             )

--- a/src/relion/_parser/motioncorrection.py
+++ b/src/relion/_parser/motioncorrection.py
@@ -14,6 +14,7 @@ MCMicrograph = namedtuple(
         "total_motion",
         "early_motion",
         "late_motion",
+        "micrograph_timestamp",
         "drift_data",
     ],
 )
@@ -29,6 +30,9 @@ MCMicrograph.total_motion.__doc__ = (
 )
 MCMicrograph.early_motion.__doc__ = "Early motion."
 MCMicrograph.late_motion.__doc__ = "Late motion."
+MCMicrograph.micrograph_timestamp.__doc__ = (
+    "Time stamp at which the micrograph was created."
+)
 
 
 MCMicrographDrift = namedtuple(
@@ -95,7 +99,8 @@ class MotionCorr(JobType):
 
         micrograph_list = []
         for j in range(len(micrograph_name)):
-            drift_data = self.collect_drift_data(micrograph_name[j], jobdir)
+            drift_data, movie_name = self.collect_drift_data(micrograph_name[j], jobdir)
+
             micrograph_list.append(
                 MCMicrograph(
                     micrograph_name[j],
@@ -106,6 +111,7 @@ class MotionCorr(JobType):
                     accum_motion_total[j],
                     accum_motion_early[j],
                     accum_motion_late[j],
+                    (self._basepath / movie_name).stat().st_ctime,
                     drift_data,
                 )
             )
@@ -140,11 +146,14 @@ class MotionCorr(JobType):
             info_table = self._find_table_from_column_name(
                 "_rlnMicrographFrameNumber", drift_star_file
             )
+            movie_table = self._find_table_from_column_name(
+                "_rlnMicrographMovieName", drift_star_file
+            )
         except (FileNotFoundError, OSError, RuntimeError, ValueError):
             return drift_data
         if info_table is None:
             logger.debug(
-                f"_rlnMicrographFrameNumber not found in file {drift_star_file}"
+                f"_rlnMicrographFrameNumber or _rlnMicrographMovieName not found in file {drift_star_file}"
             )
             return drift_data
         frame_numbers = self.parse_star_file(
@@ -156,6 +165,9 @@ class MotionCorr(JobType):
         deltays = self.parse_star_file(
             "_rlnMicrographShiftY", drift_star_file, info_table
         )
+        movie_name = self.parse_star_file(
+            "_rlnMicrographMovieName", drift_star_file, movie_table
+        )
         for f, dx, dy in zip(frame_numbers, deltaxs, deltays):
             drift_data.append(MCMicrographDrift(int(f), float(dx), float(dy)))
         try:
@@ -165,7 +177,7 @@ class MotionCorr(JobType):
             )
         except FileNotFoundError:
             return []
-        return drift_data
+        return drift_data, movie_name
 
     @staticmethod
     def for_cache(mcmicrograph):
@@ -198,6 +210,7 @@ class MotionCorr(JobType):
                 "image_number": micrograph.micrograph_number,
                 "micrograph_snapshot_full_path": micrograph.micrograph_snapshot_full_path,
                 "drift_data": micrograph.drift_data,
+                "created_time_stamp": micrograph.micrograph_timestamp,
             }
             for micrograph in micrograph_list
         ]

--- a/src/relion/dbmodel/modeltables.py
+++ b/src/relion/dbmodel/modeltables.py
@@ -186,6 +186,7 @@ def parse_sqlalchemy_table(sa_table):
 class MotionCorrectionTable(Table):
     def __init__(self):
         columns, prim_key = parse_sqlalchemy_table(sqlalchemy.MotionCorrection)
+        columns.append("created_time_stamp")
         columns.append("drift_data")
         # columns.append("job_string")
         super().__init__(


### PR DESCRIPTION
When collecting data from the motion correction job additionally collect creation time stamps for the movies that were motion corrected. The path to the imported movie can be found in the same star file as the drift data which is already collected. However, it is in a key-value section rather than a loopy one so need to extend parsing capabilities marginally. This should resolve #129. A small change will also be needed in the ISPyB service to make use of the provided time stamp.