### PR TITLE
Add custom ORM for storing pipeline/job run information

### DIFF
--- a/src/relion/zocalo/alchemy.py
+++ b/src/relion/zocalo/alchemy.py
@@ -1,6 +1,7 @@
-from sqlalchemy import Column
+from sqlalchemy import TIMESTAMP, Column, ForeignKey, String
 from sqlalchemy.dialects.mysql import INTEGER
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
 
 Base = declarative_base()
 
@@ -26,6 +27,90 @@ class ZocaloBuffer(Base):
         INTEGER(10),
         comment="Context-dependent reference to primary key IDs in other ISPyB tables",
     )
+
+
+class RelionPipelineInfo(Base):
+    __tablename__ = "RelionPipelineInfo"
+
+    pipeline_id = Column(INTEGER(10), primary_key=True)
+    image_x = Column(
+        INTEGER(5),
+        comment="Number of pixels in the x direction",
+        autoincrement=False,
+    )
+    image_y = Column(
+        INTEGER(5),
+        comment="Number of pixels in the y direction",
+        autoincrement=False,
+    )
+    microscope = Column(
+        String(10),
+        nullable=False,
+        comment="Microscope name",
+    )
+    project_path = Column(
+        String(250),
+        nullable=False,
+        comment="Path to the project directory",
+    )
+
+
+class ClusterJobInfo(Base):
+    __tablename__ = "ClusterJobInfo"
+
+    cluster = Column(
+        String(250),
+        nullable=False,
+        comment="Name of cluster",
+        primary_key=True,
+    )
+    cluster_id = Column(
+        INTEGER(10),
+        primary_key=True,
+        comment="ID of the cluster job",
+        autoincrement=False,
+        nullable=False,
+    )
+    auto_proc_program_id = Column(
+        INTEGER(10),
+        comment="Reference to the AutoProcProgram the cluster job is attached to",
+        autoincrement=False,
+    )
+    start_time = Column(
+        TIMESTAMP,
+        comment="Start time of cluster job",
+    )
+    end_time = Column(
+        TIMESTAMP,
+        comment="End time of cluster job",
+    )
+
+
+class RelionJobInfo(Base):
+    __tablename__ = "RelionJobInfo"
+
+    job_id = Column(INTEGER(10), primary_key=True)
+    cluster_id = Column(
+        INTEGER(10),
+        comment="ID of the cluster job",
+        autoincrement=False,
+    )
+    relion_start_time = Column(
+        TIMESTAMP,
+        comment="Start time of Relion job",
+    )
+    num_micrographs = Column(
+        INTEGER(10),
+        comment="Number of micrographs processed by the job if applicable",
+        autoincrement=False,
+    )
+    job_name = Column(
+        String(250),
+        nullable=False,
+        comment="Name of Relion job",
+    )
+    pipeline_id = Column(ForeignKey("RelionPipelineInfo.pipeline_id"), index=True)
+    RelionPipelineInfo = relationship("RelionPipelineInfo")
 
 
 def buffer_url() -> str:


### PR DESCRIPTION
Schema for storing some useful information about individual Relion job runs. Not all Relion jobs run on the cluster which is why there are separate `RelionJobInfo` and `ClusterJobInfo` tables. This also allows the "start" time of a job to be stored separate to its "cluster start" time which gives information on queue times.