### PR TITLE
Fully drop python3.6 support

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
       - task: UsePythonVersion@0
         displayName: Set up python
         inputs:
-          versionSpec: 3.6
+          versionSpec: 3.7
 
       - bash: python .azure-pipelines/syntax-validation.py
         displayName: Syntax validation (3.6)
@@ -86,8 +86,6 @@ stages:
       vmImage: ubuntu-20.04
     strategy:
       matrix:
-        python36:
-          PYTHON_VERSION: 3.6
         python37:
           PYTHON_VERSION: 3.7
         python38:
@@ -120,8 +118,6 @@ stages:
       vmImage: windows-latest
     strategy:
       matrix:
-        python36:
-          PYTHON_VERSION: 3.6
         python37:
           PYTHON_VERSION: 3.7
         python38:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -22,7 +22,7 @@ stages:
           versionSpec: 3.7
 
       - bash: python .azure-pipelines/syntax-validation.py
-        displayName: Syntax validation (3.6)
+        displayName: Syntax validation (3.7)
 
       - task: UsePythonVersion@0
         displayName: Set up python

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ gemmi==0.5.0
 matplotlib==3.3.2; python_version < '3.7'
 matplotlib==3.4.2; python_version >= '3.7'
 mrcfile==1.3
-numpy==1.19; python_version < '3.7'
-numpy==1.21; python_version >= '3.7'
+numpy==1.21; python_version < '3.8'
+numpy==1.22; python_version >= '3.8'
 pandas==1.1.5; python_version < '3.7'
 pandas==1.2.4; python_version >= '3.7'
 pillow==8.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
 gemmi==0.5.0
-matplotlib==3.3.2; python_version < '3.7'
-matplotlib==3.4.2; python_version >= '3.7'
+matplotlib==3.4.2
 mrcfile==1.3
 numpy==1.21; python_version < '3.8'
 numpy==1.22; python_version >= '3.8'
-pandas==1.1.5; python_version < '3.7'
-pandas==1.2.4; python_version >= '3.7'
+pandas==1.2.4
 pillow==8.4.0
 plotly==5.3.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,8 +6,8 @@ ispyb==6.9.0
 matplotlib==3.3.2; python_version < '3.7'
 matplotlib==3.4.3; python_version >= '3.7'
 mrcfile==1.3
-numpy==1.19; python_version < '3.7'
-numpy==1.21.4; python_version >= '3.7'
+numpy==1.21.4; python_version < '3.8'
+numpy==1.22.0; python_version >= '3.8'
 pandas==1.1.5; python_version < '3.7'
 pandas==1.3.4; python_version >= '3.7'
 pillow==8.4.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,13 +3,11 @@ dials_data==2.2.19
 gemmi==0.5.0
 graphviz==0.18
 ispyb==6.9.0
-matplotlib==3.3.2; python_version < '3.7'
-matplotlib==3.4.3; python_version >= '3.7'
+matplotlib==3.4.3
 mrcfile==1.3
 numpy==1.21.4; python_version < '3.8'
 numpy==1.22.0; python_version >= '3.8'
-pandas==1.1.5; python_version < '3.7'
-pandas==1.3.4; python_version >= '3.7'
+pandas==1.3.4
 pillow==8.4.0
 plotly==5.3.1
 pytest-cov==3.0.0

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,9 +1,7 @@
 gemmi==0.5.0
 ispyb==6.9.0
-matplotlib==3.3.2; python_version < '3.7'
-matplotlib==3.4.2; python_version >= '3.7'
-pandas==1.1.5; python_version < '3.7'
-pandas==1.2.4; python_version >= '3.7'
+matplotlib==3.4.2
+pandas==1.2.4
 plotly==5.3.1
 Sphinx==4.3.0
 sphinx-rtd-theme==1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: GNU General Public License v2 (GPLv2)
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -38,7 +37,7 @@ install_requires =
 packages = find:
 package_dir =
     =src
-python_requires = >=3.6
+python_requires = >=3.7
 zip_safe = False
 
 [options.entry_points]
@@ -57,7 +56,7 @@ workflows.services =
     RelionStopService = relion.zocalo.service:RelionStopService
 zocalo.wrappers =
     relion = relion.zocalo.wrapper:RelionWrapper
-zocalo.services.images.plugins = 
+zocalo.services.images.plugins =
     mrc_to_jpeg = relion.zocalo.images_service_plugin:mrc_to_jpeg
     picked_particles = relion.zocalo.images_service_plugin:picked_particles
 


### PR DESCRIPTION
and require a newer version of `numpy` for python > 3.7 so that python3.10 tests pass