### PR TITLE
Check preprocessing status if there are no new batches

### DIFF
--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -3604,8 +3604,9 @@ def run_pipeline(opts):
                     # if there isn't a new batch then check if the preprocessing is still running
                     preprocstatus = preproc.poll()
                     if preprocstatus is not None:
-                        os.remove(RUNNING_FILE)
-                        return False
+                        if preprocstatus != 0:
+                            os.remove(RUNNING_FILE)
+                        return
                     if CheckForExit():
                         return
                     # The following prevents checking the particles.star file too often

--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -1992,7 +1992,8 @@ def RunJobs(jobs, repeat, wait, schedulename):
         runjobsstring,
     ]
     # Popen rather than run because we want to run the process in the background
-    subprocess.Popen(command)
+    popen = subprocess.Popen(command)
+    return popen
 
 
 def WaitForJob(wait_for_this_job, seconds_wait):
@@ -2808,7 +2809,7 @@ def run_pipeline(opts):
         else:
             preprocess_schedule_name = PREPROCESS_SCHEDULE_PASS2
 
-        RunJobs(
+        preproc = RunJobs(
             runjobs,
             opts.preprocess_repeat_times,
             opts.preprocess_repeat_wait,
@@ -3600,6 +3601,11 @@ def run_pipeline(opts):
                                 break
 
                 if not have_new_batch:
+                    # if there isn't a new batch then check if the preprocessing is still running
+                    preprocstatus = preproc.poll()
+                    if preprocstatus is not None:
+                        os.remove(RUNNING_FILE)
+                        return False
                     if CheckForExit():
                         return
                     # The following prevents checking the particles.star file too often

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -349,6 +349,9 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
 
         if all_process_check.is_file():
             all_process_check.unlink()
+        else:
+            # if the running file is not there it was removed for a failure reason
+            success = False
 
         return success
 

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -351,6 +351,9 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
             all_process_check.unlink()
         else:
             # if the running file is not there it was removed for a failure reason
+            logger.warning(
+                "Preprocessing exited unexpectedly. Relion wrapper returning failure status"
+            )
             success = False
 
         return success


### PR DESCRIPTION
If there haven't been any new batches then check that the background process running preprocessing is still alive. If it has exited then finish the thread running Relion. If it exited with a failing error code then remove the file used to stop `relion_it` running. The wrapper currently deletes this file if it is still there at the end of processing, which it should be. We can return a failure state if it isn't as it must have been deleted because of the above preprocessing failure (`relion_it` doesn't remove it anywhere else).