### PR TITLE
Allow configuration of cluster qsub templates

### DIFF
--- a/src/relion/cli/print_default_options.py
+++ b/src/relion/cli/print_default_options.py
@@ -1,4 +1,7 @@
 import argparse
+import os
+
+import yaml
 
 from relion.cryolo_relion_it import dls_options
 from relion.cryolo_relion_it.cryolo_relion_it import RelionItOptions
@@ -16,4 +19,8 @@ def run():
     args = parser.parse_args()
     opts = RelionItOptions()
     opts.update_from(vars(dls_options))
+    if os.getenv("RELION_CLUSTER_CONFIG"):
+        with open(os.getenv("RELION_CLUSTER_CONFIG"), "r") as config:
+            cluster_config = yaml.safe_load(config)
+        opts.update_from(cluster_config)
     opts.print_options(out_file=open(args.options_file, "w"))


### PR DESCRIPTION
within `print_options`