### PR TITLE
Improve mrc to jpeg conversion for cases with outlier pixel values

### DIFF
--- a/src/relion/pipeline/__init__.py
+++ b/src/relion/pipeline/__init__.py
@@ -624,7 +624,13 @@ class PipelineRunner:
             if self._new_movies() or iteration - old_iteration:
                 if iteration - old_iteration:
                     continue_anyway = False
-                split_files = self.preprocessing(ref3d=ref3d, ref3d_angpix=ref3d_angpix)
+                try:
+                    split_files = self.preprocessing(
+                        ref3d=ref3d, ref3d_angpix=ref3d_angpix
+                    )
+                except (AttributeError, FileNotFoundError) as e:
+                    print(f"Exception encountered in preprocessing. Try again: {e}")
+                    continue
                 if not first_batch:
                     first_batch = split_files[0]
                 if self.options.do_icebreaker_group:

--- a/src/relion/zocalo/images_service_plugin.py
+++ b/src/relion/zocalo/images_service_plugin.py
@@ -5,6 +5,7 @@ import pathlib
 import time
 
 import mrcfile
+import numpy as np
 import PIL.Image
 from PIL import ImageDraw, ImageEnhance, ImageFilter
 
@@ -33,6 +34,13 @@ def mrc_to_jpeg(plugin_params):
     outfile = filepath.with_suffix(".jpeg")
     outfiles = []
     if len(data.shape) == 2:
+        mean = np.mean(data)
+        sdev = np.std(data)
+        sigma_min = mean - 3 * sdev
+        sigma_max = mean + 3 * sdev
+        data = np.ndarray.copy(data)
+        data[data < sigma_min] = sigma_min
+        data[data > sigma_max] = sigma_max
         data = data - data.min()
         data = data * 255 / data.max()
         data = data.astype("uint8")


### PR DESCRIPTION
For single frame mrcs replace outliers beyond 3 sigma from the mean with the 3 sigma boundary to avoid problems from strange pixel value distributions