### PR TITLE
Add RELION 4 support to Zocalo wrapper

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = relion
-version = 0.10.7
+version = 0.10.6
 description = Relion Python API
 long_description = file: README.rst
 author = Diamond Light Source - Scientific Software et al.

--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -82,6 +82,7 @@ class Project(RelionPipeline):
                      directory of an existing Relion project.
         """
         self.basepath = pathlib.Path(path)
+        self._version = version
         super().__init__(
             "Import/job001", locklist=[self.basepath / "default_pipeline.star"]
         )
@@ -106,8 +107,6 @@ class Project(RelionPipeline):
             #    f"Relion Project was unable to load the relion pipeline from {self.basepath}/default_pipeline.star"
             # )
         # self.res = RelionResults()
-        self._drift_cache = {}
-        self._version = version
 
     @property
     def _plock(self):

--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -37,7 +37,7 @@ logger = logging.getLogger("relion.Project")
 __all__ = []
 __author__ = "Diamond Light Source - Scientific Software"
 __email__ = "scientificsoftware@diamond.ac.uk"
-__version__ = "0.10.7"
+__version__ = "0.10.6"
 __version_tuple__ = tuple(int(x) for x in __version__.split("."))
 
 pipeline_lock = ".relion_lock"

--- a/src/relion/__init__.py
+++ b/src/relion/__init__.py
@@ -16,7 +16,7 @@ from gemmi import cif
 from relion._parser.autopick import AutoPick
 from relion._parser.class2D import Class2D
 from relion._parser.class3D import Class3D
-from relion._parser.cryolo import Cryolo
+from relion._parser.cryolo import Cryolo, CryoloAutoPick
 from relion._parser.ctffind import CTFFind
 from relion._parser.initialmodel import InitialModel
 from relion._parser.motioncorrection import MotionCorr
@@ -74,6 +74,7 @@ class Project(RelionPipeline):
         run_options=None,
         message_constructors=None,
         cluster=False,
+        version: int = 3,
     ):
         """
         Create an object representing a Relion project.
@@ -106,6 +107,7 @@ class Project(RelionPipeline):
             # )
         # self.res = RelionResults()
         self._drift_cache = {}
+        self._version = version
 
     @property
     def _plock(self):
@@ -130,12 +132,15 @@ class Project(RelionPipeline):
         resd = {
             "CtfFind": self.ctffind,
             "MotionCorr": self.motioncorrection,
-            "AutoPick": self.autopick,
+            "AutoPick": self.autopick_cryolo
+            if self.run_options.autopick_do_cryolo and self._version == 4
+            else self.autopick,
             "External/crYOLO_AutoPick/": self.cryolo,
             "Class2D": self.class2D,
             "InitialModel": self.initialmodel,
             "Class3D": self.class3D,
             "External/Icebreaker_5fig/": self.relativeicethickness,
+            "Icebreaker/Icebreaker_5fig/": self.relativeicethickness,
         }
         return resd
 
@@ -159,6 +164,11 @@ class Project(RelionPipeline):
     @functools.lru_cache(maxsize=1)
     def autopick(self):
         return AutoPick(self.basepath / "AutoPick")
+
+    @property
+    @functools.lru_cache(maxsize=1)
+    def autopick_cryolo(self):
+        return CryoloAutoPick(self.basepath / "AutoPick")
 
     @property
     @functools.lru_cache(maxsize=1)

--- a/src/relion/_parser/cryolo.py
+++ b/src/relion/_parser/cryolo.py
@@ -176,3 +176,23 @@ class Cryolo(JobType):
             for pi in partpickinfo
         ]
         return res
+
+
+class CryoloAutoPick(Cryolo):
+    def __eq__(self, other):
+        if isinstance(other, CryoloAutoPick):  # check this
+            return self._basepath == other._basepath
+        return False
+
+    def __hash__(self):
+        return hash(("relion._parser.CryoloAutoPick", self._basepath))
+
+    def __repr__(self):
+        return f"CryoloAutoPick({repr(str(self._basepath))})"
+
+    def __str__(self):
+        return f"<CryoloAutoPick parser at {self._basepath}>"
+
+    @property
+    def jobs(self):
+        return super(Cryolo, self).jobs()

--- a/src/relion/pipeline/__init__.py
+++ b/src/relion/pipeline/__init__.py
@@ -246,16 +246,20 @@ class PipelineRunner:
             return []
 
         jobs = ["relion.import.movies"]
+        aliases = {}
         if self.options.motioncor_do_own:
             jobs.append("relion.motioncorr.own")
         else:
             jobs.append("relion.motioncorr.motioncorr2")
         if self.options.do_icebreaker_job_group:
             jobs.append("icebreaker.micrograph_analysis.micrographs")
+            aliases["icebreaker.micrograph_analysis.micrographs"] = "Icebreaker_G"
         if self.options.do_icebreaker_job_flatten:
             jobs.append("icebreaker.micrograph_analysis.enhancecontrast")
+            aliases["icebreaker.micrograph_analysis.enhancecontrast"] = "Icebreaker_F"
         if self.options.do_icebreaker_fivefig:
             jobs.append("icebreaker.micrograph_analysis.summary")
+            aliases["icebreaker.micrograph_analysis.summary"] = "Icebreaker_5fig"
         jobs.append("relion.ctffind.ctffind4")
 
         for job in jobs:
@@ -264,6 +268,7 @@ class PipelineRunner:
                     job,
                     extra_params=self._extra_options(job, self.job_paths, self.options),
                     lock=self._lock,
+                    alias=aliases.get(job, ""),
                 )
             else:
                 if self._lock:

--- a/src/relion/pipeline/__init__.py
+++ b/src/relion/pipeline/__init__.py
@@ -568,7 +568,7 @@ class PipelineRunner:
                     lock=self._lock,
                 )
             except (AttributeError, FileNotFoundError) as e:
-                logger.warning(
+                logger.debug(
                     f"Exception encountered in 3D classification runner. Try again: {e}"
                 )
                 print(
@@ -749,7 +749,7 @@ class PipelineRunner:
                         ref3d=ref3d, ref3d_angpix=ref3d_angpix
                     )
                 except (AttributeError, FileNotFoundError) as e:
-                    logger.warning(
+                    logger.debug(
                         f"Exception encountered in preprocessing. Try again: {e}"
                     )
                     print(f"Exception encountered in preprocessing. Try again: {e}")

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -26,7 +26,11 @@ from relion.dbmodel.modeltables import (
     ParticlePickerTable,
     RelativeIceThicknessTable,
 )
-from relion.pipeline import PipelineRunner
+
+try:
+    from relion.pipeline import PipelineRunner
+except ImportError:
+    PipelineRunner = None
 
 logger = logging.getLogger("relion.zocalo.wrapper")
 
@@ -436,7 +440,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
             os.chdir(self.working_directory)
             if version == 3:
                 cryolo_relion_it.run_pipeline(self.opts)
-            elif version == 4:
+            elif version == 4 and PipelineRunner:
                 pipeline = PipelineRunner(
                     self.working_directory,
                     self.params["stop_file"],

--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -132,6 +132,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
         self.opts.update_from(self.params["ispyb_parameters"])
 
         # Start Relion
+        logger.info(f"Starting RELION version {self.params.get('relion_version', 3)}")
         self._relion_subthread = threading.Thread(
             target=self.start_relion,
             kwargs={"version": self.params.get("relion_version", 3)},

--- a/tests/dbmodel/test_dbnode.py
+++ b/tests/dbmodel/test_dbnode.py
@@ -13,7 +13,7 @@ def empty_options():
 
 
 @pytest.fixture
-def proj(dials_data):
+def proj(dials_data, empty_options):
     return relion.Project(
         dials_data("relion_tutorial_data", pathlib=True),
         run_options=empty_options,

--- a/tests/dbmodel/test_dbnode.py
+++ b/tests/dbmodel/test_dbnode.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import pytest
 
 import relion
@@ -7,9 +9,13 @@ from relion.dbmodel import modeltables
 from relion.dbmodel.dbnode import DBNode
 
 
+class Options(NamedTuple):
+    autopick_do_cryolo: bool = False
+
+
 @pytest.fixture
 def empty_options():
-    return []
+    return Options()
 
 
 @pytest.fixture

--- a/tests/parser/test_autopick.py
+++ b/tests/parser/test_autopick.py
@@ -19,7 +19,7 @@ def empty_options():
 
 
 @pytest.fixture
-def proj(dials_data):
+def proj(dials_data, empty_options):
     return relion.Project(
         dials_data("relion_tutorial_data", pathlib=True), run_options=empty_options
     )

--- a/tests/parser/test_autopick.py
+++ b/tests/parser/test_autopick.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 
 import sys
 from pprint import pprint
+from typing import NamedTuple
 
 import pytest
 
 import relion
 
 
+class Options(NamedTuple):
+    autopick_do_cryolo: bool = False
+
+
 @pytest.fixture
 def empty_options():
-    return []
+    return Options()
 
 
 @pytest.fixture

--- a/tests/parser/test_autopick.py
+++ b/tests/parser/test_autopick.py
@@ -31,7 +31,7 @@ def input(proj):
 
 
 @pytest.fixture
-def invalid_input(dials_data):
+def invalid_input(dials_data, empty_options):
     return relion.Project(
         dials_data("relion_tutorial_data", pathlib=True), run_options=empty_options
     )

--- a/tests/parser/test_class2D.py
+++ b/tests/parser/test_class2D.py
@@ -19,7 +19,7 @@ def empty_options():
 
 
 @pytest.fixture
-def proj(dials_data):
+def proj(dials_data, empty_options):
     return relion.Project(
         dials_data("relion_tutorial_data", pathlib=True), run_options=empty_options
     )

--- a/tests/parser/test_class2D.py
+++ b/tests/parser/test_class2D.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 
 import sys
 from pprint import pprint
+from typing import NamedTuple
 
 import pytest
 
 import relion
 
 
+class Options(NamedTuple):
+    autopick_do_cryolo: bool = False
+
+
 @pytest.fixture
 def empty_options():
-    return []
+    return Options()
 
 
 @pytest.fixture

--- a/tests/parser/test_class3D.py
+++ b/tests/parser/test_class3D.py
@@ -19,7 +19,7 @@ def empty_options():
 
 
 @pytest.fixture
-def proj(dials_data):
+def proj(dials_data, empty_options):
     return relion.Project(
         dials_data("relion_tutorial_data", pathlib=True), run_options=empty_options
     )

--- a/tests/parser/test_class3D.py
+++ b/tests/parser/test_class3D.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 
 import sys
 from pprint import pprint
+from typing import NamedTuple
 
 import pytest
 
 import relion
 
 
+class Options(NamedTuple):
+    autopick_do_cryolo: bool = False
+
+
 @pytest.fixture
 def empty_options():
-    return []
+    return Options()
 
 
 @pytest.fixture

--- a/tests/parser/test_ctffind.py
+++ b/tests/parser/test_ctffind.py
@@ -18,7 +18,7 @@ def empty_options():
 
 
 @pytest.fixture
-def proj(dials_data):
+def proj(dials_data, empty_options):
     return relion.Project(
         dials_data("relion_tutorial_data", pathlib=True), run_options=empty_options
     )

--- a/tests/parser/test_ctffind.py
+++ b/tests/parser/test_ctffind.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 import sys
+from typing import NamedTuple
 
 import pytest
 
 import relion
 
 
+class Options(NamedTuple):
+    autopick_do_cryolo: bool = False
+
+
 @pytest.fixture
 def empty_options():
-    return []
+    return Options()
 
 
 @pytest.fixture

--- a/tests/parser/test_motioncorrection.py
+++ b/tests/parser/test_motioncorrection.py
@@ -19,7 +19,7 @@ def empty_options():
 
 
 @pytest.fixture
-def proj(dials_data):
+def proj(dials_data, empty_options):
     return relion.Project(
         dials_data("relion_tutorial_data", pathlib=True), run_options=empty_options
     )

--- a/tests/parser/test_motioncorrection.py
+++ b/tests/parser/test_motioncorrection.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 
 import sys
 from pprint import pprint
+from typing import NamedTuple
 
 import pytest
 
 import relion
 
 
+class Options(NamedTuple):
+    autopick_do_cryolo: bool = False
+
+
 @pytest.fixture
 def empty_options():
-    return []
+    return Options()
 
 
 @pytest.fixture

--- a/tests/parser/test_motioncorrection.py
+++ b/tests/parser/test_motioncorrection.py
@@ -31,7 +31,7 @@ def input(proj):
 
 
 @pytest.fixture
-def invalid_input(dials_data):
+def invalid_input(dials_data, empty_options):
     return relion.Project(
         dials_data("relion_tutorial_data", pathlib=True), run_options=empty_options
     )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -87,7 +87,7 @@ def remove_corrected_star_slice(corrected_star_path, required_slice):
     return new_star_doc
 
 
-def test_basic_Project_object_behaviour(tmp_path):
+def test_basic_Project_object_behaviour(tmp_path, empty_options):
     rp1 = relion.Project(tmp_path, run_options=empty_options)
     assert rp1
     assert str(tmp_path) in str(rp1)
@@ -105,12 +105,14 @@ def test_basic_Project_object_behaviour(tmp_path):
     assert len({rp1, rp2}) == 1
 
 
-def test_create_Project_on_inaccessible_path_fails(tmp_path):
+def test_create_Project_on_inaccessible_path_fails(tmp_path, empty_options):
     with pytest.raises(ValueError):
         relion.Project(tmp_path / "does_not_exist", run_options=empty_options)
 
 
-def test_create_Project_with_cluster_information_collection_does_not_fail(dials_data):
+def test_create_Project_with_cluster_information_collection_does_not_fail(
+    dials_data, empty_options
+):
     relion.Project(
         dials_data("relion_tutorial_data", pathlib=True),
         run_options=empty_options,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -36,6 +36,7 @@ def empty_options():
         class3d_nr_classes: int = 4
         symmetry: str = "C1"
         inimodel_resol_final: int = 15
+        autopick_do_cryolo: bool = False
 
     return Options
 


### PR DESCRIPTION
If the Zocalo recipe parameter `"relion_version"` is set to `4` then run the RELION 4 pipeline rather than 3.1. Some changes were required to the processing results parser for `AutoPick` as in RELION 4 crYOLO results go into the `AutoPick` directory as well as RELION's own autopicking. (Also fixes some test related issues.)