### PR TITLE
Add a command line tool to copy a RELION project structure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mrcfile==1.3
 pandas==1.4.2
 pillow==9.1.0
 plotly==5.7.0
+procrunner==2.3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     pillow
     plotly
     pyyaml
+    procrunner
 packages = find:
 package_dir =
     =src
@@ -45,6 +46,7 @@ console_scripts =
     relipy.show = relion.cli.pipeline_viewer:run
     relipy.run_pipeline = relion.cli.run_pipeline:run
     relipy.print_options = relion.cli.print_default_options:run
+    relipy.link = relion.cli.project_linker:run
     external_job_mask_soft_edge = relion.cryolo_relion_it.mask_soft_edge_external_job:main
     external_job_select_and_split = relion.cryolo_relion_it.select_and_split_external_job:main
     external_job_reconstruct_halves = relion.cryolo_relion_it.reconstruct_halves_external_job:main

--- a/src/relion/cli/project_linker.py
+++ b/src/relion/cli/project_linker.py
@@ -81,3 +81,6 @@ def run():
                             (
                                 destination_path / jf.relative_to(project_path)
                             ).symlink_to(jf)
+        elif f.is_symlink():
+            source = f.resolve()
+            (destination_path / f.relative_to(project_path)).symlink_to(source)

--- a/src/relion/cli/project_linker.py
+++ b/src/relion/cli/project_linker.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import procrunner
+
+
+def run():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-p",
+        "--project",
+        help="Path to original RELION project directory",
+        dest="project",
+    )
+    parser.add_argument(
+        "-d",
+        "--destination",
+        help="Path to directory where new project should be created",
+        dest="destination",
+        default=".",
+    )
+    parser.add_argument(
+        "--hardlink-cutoff",
+        type=int,
+        help="Size in bytes past which a hardlink will be made to a file rather than copying",
+        default=5e6,
+    )
+    args = parser.parse_args()
+
+    required_dirs = (".Nodes", ".TMP_runfiles")
+
+    ignore_file_extensions = {"Class2D": [".jpeg"]}
+
+    if not Path(args.destination).exists():
+        Path(args.destination).mkdir()
+
+    for f in Path(args.project).glob("*"):
+        if (f.is_dir() and f in required_dirs) or f.is_file():
+            procrunner.run(
+                [
+                    "rsync",
+                    "--recursive",
+                    str(f),
+                    f"{Path(args.destination) / f.relative_to(Path(args.project))}",
+                ]
+            )
+        elif f.is_dir():
+            job_type_dir = Path(args.destination) / f.relative_to(Path(args.project))
+            job_type_dir.mkdir()
+            for job_dir in f.glob("*"):
+                if not job_dir.is_symlink():
+                    new_job_dir = Path(args.destination) / job_dir.relative_to(
+                        Path(args.project)
+                    )
+                    new_job_dir.mkdir()
+                    for jf in job_dir.glob("*"):
+                        if jf.is_file():
+                            if jf.suffix in ignore_file_extensions.get(f.name, []):
+                                continue
+                            file_linked = False
+                            if jf.stat().st_size > args.hardlink_cutoff:
+                                try:
+                                    jf.link_to(
+                                        f"{Path(args.destination) / jf.relative_to(Path(args.project))}"
+                                    )
+                                    file_linked = True
+                                except OSError:
+                                    file_linked = False
+                            if not file_linked:
+                                procrunner.run(
+                                    [
+                                        "rsync",
+                                        str(jf),
+                                        f"{Path(args.destination) / jf.relative_to(Path(args.project))}",
+                                    ]
+                                )
+                        else:
+                            (
+                                Path(args.destination)
+                                / jf.relative_to(Path(args.project))
+                            ).symlink_to(jf)


### PR DESCRIPTION
Copy necessary files such as star files and make soft links to data directories to avoid duplication of large files. In addition, if possible, hard links are made rather than copies to any files over a set size threshold.