### PR TITLE
Tomogram table changes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ zocalo.services.images.plugins =
     mrc_to_jpeg = relion.zocalo.images_service_plugin:mrc_to_jpeg
     picked_particles = relion.zocalo.images_service_plugin:picked_particles
     mrc_central_slice = relion.zocalo.images_service_plugin:mrc_central_slice
+    mrc_to_apng = relion.zocalo.images_service_plugin:mrc_to_apng
 
 [options.packages.find]
 where = src

--- a/src/relion/zocalo/images_service_plugin.py
+++ b/src/relion/zocalo/images_service_plugin.py
@@ -15,7 +15,6 @@ logger = logging.getLogger("relion.zocalo.images_service_plugin")
 def mrc_to_jpeg(plugin_params):
     filename = plugin_params.parameters("file")
     allframes = plugin_params.parameters("all_frames")
-    send_to_ispyb = plugin_params.parameters("send_to_ispyb") or 0
     if not filename or filename == "None":
         logger.error("Skipping mrc to jpeg conversion: filename not specified")
         return False
@@ -87,22 +86,6 @@ def mrc_to_jpeg(plugin_params):
         f"Converted mrc to jpeg {filename} -> {outfile} in {timing:.1f} seconds",
         extra={"image-processing-time": timing},
     )
-    if send_to_ispyb:
-        logger.info("Sending to ISPyB")
-        ispyb_command = {
-            "ispyb_command": "add_program_attachment",
-            "file_name": str(Path(outfile).name),
-            "file_path": str(Path(outfile).parent),
-        }
-
-        try:
-            plugin_params.rw.send_to(
-                "ispyb",
-                ispyb_command,
-            )
-        except Exception as e:
-            logger.warning(f"{e}")
-            return False
     if outfiles:
         return outfiles
     return outfile
@@ -182,7 +165,6 @@ def picked_particles(plugin_params):
 
 def mrc_central_slice(plugin_params):
     filename = plugin_params.parameters("file")
-    rw = plugin_params.rw
     if not filename or filename == "None":
         logger.error("Skipping mrc to jpeg conversion: filename not specified")
         return False
@@ -229,35 +211,12 @@ def mrc_central_slice(plugin_params):
         extra={"image-processing-time": timing},
     )
 
-    logger.info("Sending to ISPyB")
-    ispyb_command = {
-        "ispyb_command": "add_program_attachment",
-        "file_name": str(Path(outfile).name),
-        "file_path": str(Path(outfile).parent),
-    }
-
-    class RW_mock:
-        def dummy(self, *args, **kwargs):
-            pass
-
-    if not rw:
-        rw = RW_mock()
-        rw.send = rw.dummy
-
-    if isinstance(rw, RW_mock):
-        rw.send("ispyb_connector", ispyb_command)
-    else:
-        rw.send_to(
-            "ispyb",
-            ispyb_command,
-        )
     Path(outfile).chmod(0o740)
     return outfile
 
 
 def mrc_to_apng(plugin_params):
     filename = plugin_params.parameters("file")
-    rw = plugin_params.rw
 
     if not filename or filename == "None":
         logger.error("Skipping mrc to jpeg conversion: filename not specified")
@@ -303,27 +262,5 @@ def mrc_to_apng(plugin_params):
         f"Converted mrc to apng {filename} -> {outfile} in {timing:.1f} seconds"
     )
 
-    ispyb_command = {
-        "ispyb_command": "add_program_attachment",
-        "file_name": str(Path(outfile).name),
-        "file_path": str(Path(outfile).parent),
-    }
-
-    class RW_mock:
-        def dummy(self, *args, **kwargs):
-            pass
-
-    if not rw:
-        rw = RW_mock()
-        rw.send = rw.dummy
-
-    logger.info("Sending to ISPyB")
-    if isinstance(rw, RW_mock):
-        rw.send("ispyb_connector", ispyb_command)
-    else:
-        rw.send_to(
-            "ispyb",
-            ispyb_command,
-        )
     Path(outfile).chmod(0o740)
     return outfile

--- a/src/relion/zocalo/tomo_align.py
+++ b/src/relion/zocalo/tomo_align.py
@@ -355,7 +355,7 @@ class TomoAlign(CommonService):
                 },
             )
             rw.transport.send(
-                destination="images",
+                destination="movie",
                 message={
                     "parameters": {"images_command": "mrc_to_apng"},
                     "file": tomo_params.aretomo_output_file,
@@ -370,7 +370,7 @@ class TomoAlign(CommonService):
                 },
             )
             rw.send_to(
-                "images",
+                "movie",
                 {
                     "parameters": {"images_command": "mrc_to_apng"},
                     "file": tomo_params.aretomo_output_file,

--- a/src/relion/zocalo/tomo_align.py
+++ b/src/relion/zocalo/tomo_align.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 import os.path
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import plotly.express as px
 import procrunner
@@ -38,7 +38,7 @@ class TomoParameters(BaseModel):
     refine_flag: Optional[int] = None
     out_imod: int = 1
     out_imod_xf: Optional[int] = None
-    dark_tol: Optional[int, str] = None
+    dark_tol: Optional[Union[int, str]] = None
     manual_tilt_offset: Optional[int] = None
 
     @validator("input_file_list", pre=True)

--- a/src/relion/zocalo/tomo_align.py
+++ b/src/relion/zocalo/tomo_align.py
@@ -202,7 +202,7 @@ class TomoAlign(CommonService):
             self.alignment_output_dir + "/" + self.stack_name + "_aretomo.mrc"
         )
         self.plot_file = self.stack_name + "_xy_shift_plot.json"
-        self.plot_path = self.alignment_output_dir + self.plot_file
+        self.plot_path = self.alignment_output_dir + "/" + self.plot_file
         self.dark_images_file = self.stack_name + "_DarkImgs.txt"
         self.xy_proj_file = self.stack_name + "_aretomo_projXY.jpeg"
         self.xz_proj_file = self.stack_name + "_aretomo_projXZ.jpeg"
@@ -376,23 +376,22 @@ class TomoAlign(CommonService):
                     "file": tomo_params.aretomo_output_file,
                 },
             )
-
-        self.log.info(
-            f"Sending to images service {self.xy_proj_file}, {self.xz_proj_file}"
-        )
+        xy_input = str(Path(self.xy_proj_file).with_suffix(".mrc"))
+        xz_input = str(Path(self.xz_proj_file).with_suffix(".mrc"))
+        self.log.info(f"Sending to images service {xy_input}, {xz_input}")
         if isinstance(rw, RW_mock):
             rw.transport.send(
                 destination="projxy",
                 message={
                     "parameters": {"images_command": "mrc_to_jpeg"},
-                    "file": self.xy_proj_file,
+                    "file": xy_input,
                 },
             )
             rw.transport.send(
                 destination="projxz",
                 message={
                     "parameters": {"images_command": "mrc_to_jpeg"},
-                    "file": self.xz_proj_file,
+                    "file": xz_input,
                 },
             )
         else:
@@ -400,14 +399,14 @@ class TomoAlign(CommonService):
                 "projxy",
                 {
                     "parameters": {"images_command": "mrc_to_jpeg"},
-                    "file": self.xy_proj_file,
+                    "file": xy_input,
                 },
             )
             rw.send_to(
                 "projxz",
                 {
                     "parameters": {"images_command": "mrc_to_jpeg"},
-                    "file": self.xz_proj_file,
+                    "file": xz_input,
                 },
             )
 

--- a/src/relion/zocalo/tomo_align.py
+++ b/src/relion/zocalo/tomo_align.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 import os.path
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import plotly.express as px
 import procrunner
@@ -17,29 +17,29 @@ from workflows.services.common_service import CommonService
 class TomoParameters(BaseModel):
     input_file_list: List[list]
     stack_file: str = Field(..., min_length=1)
-    position: str | None = None
-    aretomo_output_file: str | None = None
+    position: Optional[str] = None
+    aretomo_output_file: Optional[str] = None
     vol_z: int = 1200
-    align: int | None = None
+    align: Optional[int] = None
     out_bin: int = 4
-    tilt_axis: float | None = None
+    tilt_axis: Optional[float] = None
     tilt_cor: int = 1
-    flip_int: int | None = None
+    flip_int: Optional[int] = None
     flip_vol: int = 1
-    wbp: int | None = None
+    wbp: Optional[int] = None
     roi_file: list = []
-    patch: int | None = None
-    kv: int | None = None
-    align_file: str | None = None
-    angle_file: str | None = None
-    align_z: int | None = None
-    pix_size: int | None = None
-    init_val: int | None = None
-    refine_flag: int | None = None
+    patch: Optional[int] = None
+    kv: Optional[int] = None
+    align_file: Optional[str] = None
+    angle_file: Optional[str] = None
+    align_z: Optional[int] = None
+    pix_size: Optional[int] = None
+    init_val: Optional[int] = None
+    refine_flag: Optional[int] = None
     out_imod: int = 1
-    out_imod_xf: int | None = None
-    dark_tol: int | str | None = None
-    manual_tilt_offset: int | None = None
+    out_imod_xf: Optional[int] = None
+    dark_tol: Optional[int, str] = None
+    manual_tilt_offset: Optional[int] = None
 
     @validator("input_file_list", pre=True)
     def convert_to_list_of_lists(cls, v):

--- a/src/relion/zocalo/tomo_align.py
+++ b/src/relion/zocalo/tomo_align.py
@@ -283,15 +283,6 @@ class TomoAlign(CommonService):
                 "store_result": "ispyb_tomogram_id",
             }
         ]
-        if self.plot_path:
-            ispyb_command_list.append(
-                {
-                    "ispyb_command": "add_program_attachment",
-                    "file_name": str(Path(self.plot_path).name),
-                    "file_path": str(Path(self.plot_path).parent),
-                    "file_type": "Graph",
-                }
-            )
 
         missing_indices = []
         if Path(self.dark_images_file).is_file():

--- a/src/relion/zocalo/tomo_align.py
+++ b/src/relion/zocalo/tomo_align.py
@@ -376,8 +376,16 @@ class TomoAlign(CommonService):
                     "file": tomo_params.aretomo_output_file,
                 },
             )
-        xy_input = str(Path(self.xy_proj_file).with_suffix(".mrc"))
-        xz_input = str(Path(self.xz_proj_file).with_suffix(".mrc"))
+        xy_input = (
+            self.alignment_output_dir
+            + "/"
+            + str(Path(self.xy_proj_file).with_suffix(".mrc"))
+        )
+        xz_input = (
+            self.alignment_output_dir
+            + "/"
+            + str(Path(self.xz_proj_file).with_suffix(".mrc"))
+        )
         self.log.info(f"Sending to images service {xy_input}, {xz_input}")
         if isinstance(rw, RW_mock):
             rw.transport.send(

--- a/src/relion/zocalo/tomo_align.py
+++ b/src/relion/zocalo/tomo_align.py
@@ -102,7 +102,7 @@ class TomoAlign(CommonService):
         x_shift = []
         y_shift = []
         self.refined_tilts = []
-        aln_files = list(Path(tomo_parameters.aretomo_output_file).parent.glob("*.aln"))
+        aln_files = list(Path(self.alignment_output_dir).glob("*.aln"))
 
         file_name = Path(tomo_parameters.stack_file).stem
         for aln_file in aln_files:
@@ -198,7 +198,9 @@ class TomoAlign(CommonService):
         self.alignment_output_dir = str(Path(tomo_params.stack_file).parent)
         self.stack_name = str(Path(tomo_params.stack_file).stem)
 
-        tomo_params.aretomo_output_file = self.stack_name + "_aretomo.mrc"
+        tomo_params.aretomo_output_file = (
+            self.alignment_output_dir + "/" + self.stack_name + "_aretomo.mrc"
+        )
         self.plot_file = self.stack_name + "_xy_shift_plot.json"
         self.plot_path = self.alignment_output_dir + self.plot_file
         self.dark_images_file = self.stack_name + "_DarkImgs.txt"
@@ -241,7 +243,7 @@ class TomoAlign(CommonService):
 
         if tomo_params.out_imod:
             self.imod_directory = (
-                self.alignment_output_dir + self.stack_name + "_aretomo_Imod"
+                self.alignment_output_dir + "/" + self.stack_name + "_aretomo_Imod"
             )
             _f = Path(self.imod_directory)
             _f.chmod(0o750)

--- a/src/relion/zocalo/tomo_align.py
+++ b/src/relion/zocalo/tomo_align.py
@@ -208,7 +208,9 @@ class TomoAlign(CommonService):
         self.xz_proj_file = self.stack_name + "_aretomo_projXZ.jpeg"
         self.central_slice_file = self.stack_name + "_aretomo_thumbnail.jpeg"
         self.tomogram_movie_file = self.stack_name + "_aretomo_movie.png"
-        self.newstack_path = self.stack_name + "_newstack.txt"
+        self.newstack_path = (
+            self.alignment_output_dir + "/" + self.stack_name + "_newstack.txt"
+        )
 
         newstack_result = self.newstack(tomo_params)
         if newstack_result.returncode:


### PR DESCRIPTION
Insert plots and images from the tomo_align service rather than adding as attachments in the images service. They can go directly into the Tomogram table now that the fields exist.