### PR TITLE
Calculate initial model class number from occupation

### DIFF
--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -28,7 +28,7 @@ def _max_class(ini_model_dir: Path) -> int:
     last_iteration_number = max(
         (int(n) for n in number_list if n.isnumeric()), default=0
     )
-    data_file = f"run_it{last_iteration_number:03d}_data.star"
+    data_file = ini_model_dir / f"run_it{last_iteration_number:03d}_data.star"
     gemmi_readable_path = os.fspath(data_file)
     star_doc = cif.read_file(gemmi_readable_path)
     class_number_values = star_doc[1].find_loop("_rlnClassNumber")
@@ -172,13 +172,13 @@ class RelionPipeline:
                 self._nodes[self._nodes.index(f._path)].propagate(
                     ("init_model_class_num", "init_model_class_num")
                 )
-            if (
+            elif (
                 str(f._path.parent.parent) == "InitialModel"
                 and "initial" in f._path.name
             ):
                 self._nodes[self._nodes.index(f._path)].environment[
                     "init_model_class_num"
-                ] = _max_class(f._path.parent)
+                ] = _max_class(Path(star_path).parent / f._path.parent)
                 self._nodes[self._nodes.index(f._path)].propagate(
                     ("init_model_class_num", "init_model_class_num")
                 )

--- a/src/relion/_parser/relion_pipeline.py
+++ b/src/relion/_parser/relion_pipeline.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import os
 import pathlib
 import warnings
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from threading import RLock
 from typing import Optional, Tuple
 
@@ -19,6 +21,19 @@ import datetime
 
 from relion._parser.processgraph import ProcessGraph
 from relion._parser.processnode import ProcessNode
+
+
+def _max_class(ini_model_dir: Path) -> int:
+    number_list = [entry.stem[6:9] for entry in (ini_model_dir).glob("run_it*.star")]
+    last_iteration_number = max(
+        (int(n) for n in number_list if n.isnumeric()), default=0
+    )
+    data_file = f"run_it{last_iteration_number:03d}_data.star"
+    gemmi_readable_path = os.fspath(data_file)
+    star_doc = cif.read_file(gemmi_readable_path)
+    class_number_values = star_doc[1].find_loop("_rlnClassNumber")
+    counts = Counter(list(class_number_values))
+    return int(counts.most_common(1)[0][0])
 
 
 class RelionPipeline:
@@ -154,6 +169,16 @@ class RelionPipeline:
                 self._nodes[self._nodes.index(f._path)].environment[
                     "init_model_class_num"
                 ] = int(f._path.stem.split("class")[-1].split("_")[0])
+                self._nodes[self._nodes.index(f._path)].propagate(
+                    ("init_model_class_num", "init_model_class_num")
+                )
+            if (
+                str(f._path.parent.parent) == "InitialModel"
+                and "initial" in f._path.name
+            ):
+                self._nodes[self._nodes.index(f._path)].environment[
+                    "init_model_class_num"
+                ] = _max_class(f._path.parent)
                 self._nodes[self._nodes.index(f._path)].propagate(
                     ("init_model_class_num", "init_model_class_num")
                 )


### PR DESCRIPTION
Currently the initial model class number is collected from the name of the file as determined from `default_pipeline.star`. When using `initial_model.mrc` this can't be done so instead parse the data star file of the initial model job and choose the largest class (not sure if this is strictly correct).