### PR TITLE
Use cryolo to calculate the particle diameter

### DIFF
--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -672,7 +672,7 @@ class RelionItOptions(BaseModel):
     # If 0 and use_particle_diameter is False then the other parameters are taken from the input form
     particle_diameter: float = 0
     # Whether to estimate the particle diameter from cryolo picked particles
-    get_particle_diameter: bool = False
+    estimate_particle_diameter: bool = False
     # Use reference-free Laplacian-of-Gaussian picking (otherwise use reference-based template matching instead)
     autopick_do_LoG: bool = True
     # Minimum and maximum diameter in Angstrom for the LoG filter

--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -671,8 +671,8 @@ class RelionItOptions(BaseModel):
     # Estimated particle diameter in Angstroms. Used to calculate other parameters such as mask diameter and extraction box size
     # If 0 and use_particle_diameter is False then the other parameters are taken from the input form
     particle_diameter: float = 0
-    # Whether to calculate the particle diameter from cryolo picked particles
-    use_particle_diameter: bool = False
+    # Whether to estimate the particle diameter from cryolo picked particles
+    get_particle_diameter: bool = False
     # Use reference-free Laplacian-of-Gaussian picking (otherwise use reference-based template matching instead)
     autopick_do_LoG: bool = True
     # Minimum and maximum diameter in Angstrom for the LoG filter

--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -671,8 +671,6 @@ class RelionItOptions(BaseModel):
     # Estimated particle diamter in Angstroms. Used to calculate other parameters such as mask diameter and extraction box size
     # If 0 then unused
     particle_diameter: float = 0
-    # Estimate the particle diameter from the particles picked by cryolo
-    estimate_particle_diameter: bool = True
     # Use reference-free Laplacian-of-Gaussian picking (otherwise use reference-based template matching instead)
     autopick_do_LoG: bool = True
     # Minimum and maximum diameter in Angstrom for the LoG filter
@@ -886,7 +884,7 @@ class RelionItOptions(BaseModel):
 
     ### Extract parameters
     # Diameter for background normalisation (in pixels; negative value defaults to 75% box size)
-    extract_bg_diameter: float = -1
+    extract_bg_diameter: int = -1
     # How many MPI processes to use for running particle extraction?
     extract_mpi: int = 1
     # Submit Extract job to the cluster?

--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -671,6 +671,8 @@ class RelionItOptions(BaseModel):
     # Estimated particle diamter in Angstroms. Used to calculate other parameters such as mask diameter and extraction box size
     # If 0 then unused
     particle_diameter: float = 0
+    # Estimate the particle diameter from the particles picked by cryolo
+    estimate_particle_diameter: bool = True
     # Use reference-free Laplacian-of-Gaussian picking (otherwise use reference-based template matching instead)
     autopick_do_LoG: bool = True
     # Minimum and maximum diameter in Angstrom for the LoG filter

--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -686,7 +686,7 @@ class RelionItOptions(BaseModel):
     #
     # References for reference-based picking (when autopick_do_LoG = False)
     autopick_2dreferences: str = ""
-    # OR: provide a 3D references for reference-based picking (when autopick_do_LoG = False)
+    # OR provide a 3D references for reference-based picking (when autopick_do_LoG = False)
     autopick_3dreference: str = ""
 
     # Threshold for reference-based autopicking (threshold 0 will pick too many particles. Default of 0.4 is hopefully better. Ultimately, just hope classification will sort it all out...)
@@ -696,9 +696,9 @@ class RelionItOptions(BaseModel):
     #
     # For both LoG and refs:
     #
-    # Use this to remove false positives from carbon edges (useful range: 1.0-1.2, -1 to switch off)
+    # Use this to remove false positives from carbon edges (useful range 1.0-1.2, -1 to switch off)
     autopick_stddev_noise: float = -1
-    # Use this to remove false positives from carbon edges (useful range: -0.5-0.0; -999 to switch off)
+    # Use this to remove false positives from carbon edges (useful range -0.5-0.0; -999 to switch off)
     autopick_avg_noise: float = -999
     #
     # OR:
@@ -833,9 +833,9 @@ class RelionItOptions(BaseModel):
     ctffind_defocus_max: int = 50000
     ctffind_defocus_min: int = 5000
     ctffind_defocus_step: int = 500
-    # For Gctf: ignore parameters on the 'Searches' tab?
+    # For Gctf, ignore parameters on the 'Searches' tab?
     ctffind_do_ignore_search_params: bool = True
-    # For Gctf: perform equi-phase averaging?
+    # For Gctf, perform equi-phase averaging?
     ctffind_do_EPA: bool = True
     # Also estimate phase shifts (for VPP data)
     ctffind_do_phaseshift: bool = False
@@ -885,7 +885,7 @@ class RelionItOptions(BaseModel):
     autopick_ref_angpix: float = -1
 
     ### Extract parameters
-    # Diameter for background normalisation (in pixels; negative value: default is 75% box size)
+    # Diameter for background normalisation (in pixels; negative value defaults to 75% box size)
     extract_bg_diameter: float = -1
     # How many MPI processes to use for running particle extraction?
     extract_mpi: int = 1

--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -668,9 +668,11 @@ class RelionItOptions(BaseModel):
     # Most cases won't need changes here...
 
     ### Autopick parameters
-    # Estimated particle diamter in Angstroms. Used to calculate other parameters such as mask diameter and extraction box size
-    # If 0 then unused
+    # Estimated particle diameter in Angstroms. Used to calculate other parameters such as mask diameter and extraction box size
+    # If 0 and use_particle_diameter is False then the other parameters are taken from the input form
     particle_diameter: float = 0
+    # Whether to calculate the particle diameter from cryolo picked particles
+    use_particle_diameter: bool = False
     # Use reference-free Laplacian-of-Gaussian picking (otherwise use reference-based template matching instead)
     autopick_do_LoG: bool = True
     # Minimum and maximum diameter in Angstrom for the LoG filter

--- a/src/relion/pipeline/__init__.py
+++ b/src/relion/pipeline/__init__.py
@@ -200,6 +200,13 @@ class PipelineRunner:
                 self.job_paths["relion.initialmodel"] = list(
                     (self.path / "InitialModel").glob("*")
                 )[0].relative_to(self.path)
+            if (
+                self.job_paths.get("cryolo.autopick")
+                and (self.path / "AutoPick").is_dir()
+                and self.options.particle_diameter
+            ):
+                # set the particle diameter from the cryolo job
+                self._set_particle_diameter(self.job_paths["cryolo.autopick"])
 
     def _get_select_file(
         self, class_job_path: pathlib.Path, option_name: str = "fn_img"
@@ -428,7 +435,7 @@ class PipelineRunner:
                         logger.warning(f"Failed to register fresh job: {job}")
                         return None
 
-                if job == "cryolo.autopick" and self.options.estimate_particle_diameter:
+                if job == "cryolo.autopick" and self.options.particle_diameter:
                     # set the particle diameter from the output of the first batch
                     self._set_particle_diameter(self.job_paths[job])
             else:

--- a/src/relion/pipeline/__init__.py
+++ b/src/relion/pipeline/__init__.py
@@ -205,7 +205,7 @@ class PipelineRunner:
             if (
                 self.job_paths.get("cryolo.autopick")
                 and (self.path / "AutoPick").is_dir()
-                and self.options.use_particle_diameter
+                and self.options.get_particle_diameter
             ):
                 # set the particle diameter from the cryolo job
                 self._set_particle_diameter(self.job_paths["cryolo.autopick"])
@@ -439,7 +439,7 @@ class PipelineRunner:
                         logger.warning(f"Failed to register fresh job: {job}")
                         return None
 
-                if job == "cryolo.autopick" and self.options.use_particle_diameter:
+                if job == "cryolo.autopick" and self.options.get_particle_diameter:
                     # set the particle diameter from the output of the first batch
                     self._set_particle_diameter(self.job_paths[job])
             else:

--- a/src/relion/pipeline/__init__.py
+++ b/src/relion/pipeline/__init__.py
@@ -1152,6 +1152,8 @@ class PipelineRunner:
                         ]
                         for sf in new_batches:
                             self._queues["ib_group"][iteration].put(sf)
+                        if not self.options.do_class2d:
+                            self._passes[iteration].update(new_batches)
                 if self.options.do_class2d:
                     if class_thread is None and not iteration:
                         curr_angpix = (

--- a/src/relion/pipeline/__init__.py
+++ b/src/relion/pipeline/__init__.py
@@ -205,7 +205,7 @@ class PipelineRunner:
             if (
                 self.job_paths.get("cryolo.autopick")
                 and (self.path / "AutoPick").is_dir()
-                and self.options.get_particle_diameter
+                and self.options.estimate_particle_diameter
             ):
                 # set the particle diameter from the cryolo job
                 self._set_particle_diameter(self.job_paths["cryolo.autopick"])
@@ -439,7 +439,7 @@ class PipelineRunner:
                         logger.warning(f"Failed to register fresh job: {job}")
                         return None
 
-                if job == "cryolo.autopick" and self.options.get_particle_diameter:
+                if job == "cryolo.autopick" and self.options.estimate_particle_diameter:
                     # set the particle diameter from the output of the first batch
                     self._set_particle_diameter(self.job_paths[job])
             else:

--- a/src/relion/pipeline/__init__.py
+++ b/src/relion/pipeline/__init__.py
@@ -205,7 +205,7 @@ class PipelineRunner:
             if (
                 self.job_paths.get("cryolo.autopick")
                 and (self.path / "AutoPick").is_dir()
-                and self.options.particle_diameter
+                and self.options.use_particle_diameter
             ):
                 # set the particle diameter from the cryolo job
                 self._set_particle_diameter(self.job_paths["cryolo.autopick"])
@@ -439,7 +439,7 @@ class PipelineRunner:
                         logger.warning(f"Failed to register fresh job: {job}")
                         return None
 
-                if job == "cryolo.autopick" and self.options.particle_diameter:
+                if job == "cryolo.autopick" and self.options.use_particle_diameter:
                     # set the particle diameter from the output of the first batch
                     self._set_particle_diameter(self.job_paths[job])
             else:


### PR DESCRIPTION
Particles picked by cryolo are used to estimate the particle diameter if the option `estimate_particle_diameter` is set to true.
Also included are changes for the new locking methods in CCP-EM pipeliner, and fixes for running class selection if the first batch seen is incomplete.