### PR TITLE
Run a single 3D classification batch

### DIFF
--- a/src/relion/_parser/combine_star_files.py
+++ b/src/relion/_parser/combine_star_files.py
@@ -86,8 +86,11 @@ def split_star_file(
         dictionary_to_write = {"optics": data_optics, "particles": particles_to_use}
         starfile.write(
             dictionary_to_write,
-            output_dir / f"particles_split{split+1}.star",
+            output_dir / f".particles_split{split+1}_tmp.star",
             overwrite=True,
+        )
+        (output_dir / f".particles_split{split+1}_tmp.star").rename(
+            output_dir / f"particles_split{split+1}.star"
         )
 
     print(

--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -759,7 +759,7 @@ class RelionItOptions(BaseModel):
     class3d_ref_is_ctf_corrected: bool = True
     # Initial lowpass filter on reference
     class3d_ini_lowpass: int = 40
-    # If non-zero use this as the batch size for a single batch of 3D classification which will update whenever a @D classification batch completes (only available when running RELION 4 through the pipeliner)
+    # If non-zero use this as the batch size for a single batch of 3D classification which will update whenever a 2D classification batch completes (only available when running RELION 4 through the pipeliner)
     class3d_max_size: int = 200000
 
     ### Use the largest 3D class from the first batch as a 3D reference for a second pass of autopicking? (only when do_class3d is True)

--- a/src/relion/cryolo_relion_it/cryolo_relion_it.py
+++ b/src/relion/cryolo_relion_it/cryolo_relion_it.py
@@ -759,6 +759,8 @@ class RelionItOptions(BaseModel):
     class3d_ref_is_ctf_corrected: bool = True
     # Initial lowpass filter on reference
     class3d_ini_lowpass: int = 40
+    # If non-zero use this as the batch size for a single batch of 3D classification which will update whenever a @D classification batch completes (only available when running RELION 4 through the pipeliner)
+    class3d_max_size: int = 200000
 
     ### Use the largest 3D class from the first batch as a 3D reference for a second pass of autopicking? (only when do_class3d is True)
     do_second_pass: bool = True

--- a/src/relion/pipeline/__init__.py
+++ b/src/relion/pipeline/__init__.py
@@ -698,9 +698,17 @@ class PipelineRunner:
         boxsize: Optional[int] = None,
         iteration: int = 0,
         single_job: bool = True,
+        clear_queue: bool = True,
     ):
         while True:
             batch_file = self._queues["class3D"][iteration].get()
+            if clear_queue and self.job_paths_batch.get("relion.class3d", {}).get(
+                batch_file
+            ):
+                # clear the queue down to the most recent item (doesn't need to function perfectly)
+                while self._queues["class3D"][iteration].qsize() > 1:
+                    self._queues["class3D"][iteration].get()
+                batch_file = self._queues["class3D"][iteration].get()
             if not batch_file:
                 return
             if (
@@ -1109,6 +1117,7 @@ class PipelineRunner:
                                 "angpix": angpix,
                                 "boxsize": boxsize,
                                 "single_job": True if files_to_combine else False,
+                                "clear_queue": True if files_to_combine else False,
                             },
                         )
                         class3d_thread.start()

--- a/src/relion/pipeline/__init__.py
+++ b/src/relion/pipeline/__init__.py
@@ -820,6 +820,7 @@ class PipelineRunner:
         last_completed_split = 0
         batch_size_3d = 0
         class3d_thread = None
+        stop_3d = False
         while True:
             try:
                 batch_file, batch_is_complete = self._queues["class2D"][iteration].get()
@@ -1101,12 +1102,15 @@ class PipelineRunner:
                     split_file_column = list(
                         split_file_block.find_loop("_rlnCoordinateX")
                     )
-
+                if stop_3d:
+                    continue
                 if (
                     len(split_file_column)
                     >= (last_completed_split + 1) * self.options.batch_size
                     and files_to_combine
                 ) or (batch_is_complete and not fraction_of_classes_to_remove):
+                    if len(split_file_column) == batch_size_3d:
+                        stop_3d = True
                     # if the split is complete then run 3D classification
                     if self.options.do_class3d and class3d_thread is None:
                         class3d_thread = threading.Thread(

--- a/tests/parser/test_combine_star_files.py
+++ b/tests/parser/test_combine_star_files.py
@@ -8,8 +8,9 @@ import pandas as pd
 from relion._parser import combine_star_files
 
 
+@mock.patch("relion._parser.combine_star_files.Path.rename")
 @mock.patch("relion._parser.combine_star_files.starfile")
-def test_combine_star_files(mock_starfile, tmp_path):
+def test_combine_star_files(mock_starfile, mock_rename, tmp_path):
     """Check that star files can be read in and a combine file written"""
     Path(tmp_path / "particles_split1.star").touch()
     Path(tmp_path / "particles_split2.star").touch()
@@ -55,8 +56,9 @@ def test_combine_star_files(mock_starfile, tmp_path):
     assert write_call[1] == {"overwrite": True}
 
 
+@mock.patch("relion._parser.combine_star_files.Path.rename")
 @mock.patch("relion._parser.combine_star_files.starfile")
-def test_split_star_file_n_splits(mock_starfile, tmp_path):
+def test_split_star_file_n_splits(mock_starfile, mock_rename, tmp_path):
     """Test the star file splitting when given number of files to split into"""
     # set up a mock star file structure
     mock_starfile.read.return_value = {
@@ -92,7 +94,7 @@ def test_split_star_file_n_splits(mock_starfile, tmp_path):
         .all()
         .all()
     )
-    assert write_call[0][0][1] == tmp_path / "particles_split1.star"
+    assert write_call[0][0][1] == tmp_path / ".particles_split1_tmp.star"
     assert write_call[0][1] == {"overwrite": True}
 
     assert (
@@ -111,12 +113,16 @@ def test_split_star_file_n_splits(mock_starfile, tmp_path):
         .all()
         .all()
     )
-    assert write_call[1][0][1] == tmp_path / "particles_split2.star"
+    assert write_call[1][0][1] == tmp_path / ".particles_split2_tmp.star"
     assert write_call[1][1] == {"overwrite": True}
 
+    assert mock_rename.call_count == 2
+    mock_rename.assert_called_with(tmp_path / "particles_split2.star")
 
+
+@mock.patch("relion._parser.combine_star_files.Path.rename")
 @mock.patch("relion._parser.combine_star_files.starfile")
-def test_split_star_file_n_particles(mock_starfile, tmp_path):
+def test_split_star_file_n_particles(mock_starfile, mock_rename, tmp_path):
     """Test the star file splitting when given number of particles for each file"""
     # set up a mock star file structure
     mock_starfile.read.return_value = {
@@ -152,7 +158,7 @@ def test_split_star_file_n_particles(mock_starfile, tmp_path):
         .all()
         .all()
     )
-    assert write_call[0][0][1] == tmp_path / "particles_split1.star"
+    assert write_call[0][0][1] == tmp_path / ".particles_split1_tmp.star"
     assert write_call[0][1] == {"overwrite": True}
 
     assert (
@@ -171,8 +177,11 @@ def test_split_star_file_n_particles(mock_starfile, tmp_path):
         .all()
         .all()
     )
-    assert write_call[1][0][1] == tmp_path / "particles_split2.star"
+    assert write_call[1][0][1] == tmp_path / ".particles_split2_tmp.star"
     assert write_call[1][1] == {"overwrite": True}
+
+    assert mock_rename.call_count == 2
+    mock_rename.assert_called_with(tmp_path / "particles_split2.star")
 
 
 @mock.patch("relion._parser.combine_star_files.argparse._sys")


### PR DESCRIPTION
When automated 2D class selection is being used just run a single batch of 3D classification. Allow the size of this batch to be varied independently of the 2D classification batch size. Every time a 2D class batch is complete re-run the 3D classification job with the new data until the 3D batch is complete. This will reduce the number of 3D class jobs and will hopefully be more useful