### PR TITLE
Allow extract_downscale to not be present in ispyb_parameters

### DIFF
--- a/src/relion/zocalo/wrapper.py
+++ b/src/relion/zocalo/wrapper.py
@@ -125,7 +125,7 @@ class RelionWrapper(zocalo.wrapper.BaseWrapper):
                     pass
 
         # Could be given either a requirement to downscale, or a downscaled box size
-        if self.params["ispyb_parameters"]["extract_downscale"]:
+        if self.params["ispyb_parameters"].get("extract_downscale"):
             self.params["ispyb_parameters"][
                 "extract_small_boxsize"
             ] = cryolo_relion_it.calculate_downscaled_box_size(


### PR DESCRIPTION
For backwards compatibility with older pipeline parameters